### PR TITLE
Expose Services via read API

### DIFF
--- a/features/api/service/reading.feature
+++ b/features/api/service/reading.feature
@@ -1,0 +1,73 @@
+Feature: Service READ APIs
+
+  As a RESTful client or user
+  I should be able to read information about services
+
+
+  Scenario: Fetching all services 
+
+    Given there are services
+    When I GET "/api/v1/services"
+    Then the response should be 200
+    And the body should be JSON:
+    """
+      [{
+        "name" : "Auditlog-as-a-Service",
+        "artifacts" : [
+            "com.github.lookout:alas",
+            "com.github.lookout.puppet:puppet-alas",
+            "com.github.lookout:puppet-mysql"
+        ],
+        "pipelines" : [
+            "detoprod"
+        ],
+        "promotions" : [
+            "status-check",
+            "jenkins-smoke"
+        ]
+      },
+      {
+        "name" : "Fun-as-a-Service",
+        "artifacts" : [
+            "com.github.lookout:foas",
+            "com.github.lookout.puppet:puppet-foas",
+            "com.github.lookout:puppet-mysql"
+        ],
+        "pipelines" : [
+            "detoprod"
+        ],
+        "promotions" : [
+            "status-check",
+            "jenkins-smoke"
+        ]
+      }]
+    """
+
+  Scenario: Fetching an service by name that exists
+
+    Given there is an service
+    When I GET "/api/v1/services/Fun-as-a-Service"
+    Then the response should be 200
+    And the body should be JSON:
+    """
+      {
+        "name" : "Fun-as-a-Service",
+        "artifacts" : [
+            "com.github.lookout:foas",
+            "com.github.lookout.puppet:puppet-foas",
+            "com.github.lookout:puppet-mysql"
+        ],
+        "pipelines" : [
+            "detoprod"
+        ],
+        "promotions" : [
+            "status-check",
+            "jenkins-smoke"
+        ]
+      }
+    """
+
+  Scenario: Fetching an service by name that doesn't exist
+
+    When I GET "/api/v1/services/Fail-as-a-Service"
+    Then the response should be 404

--- a/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
@@ -18,6 +18,9 @@ import org.hibernate.SessionFactory
 import org.hibernate.Transaction
 import org.hibernate.context.internal.ManagedSessionContext
 
+import deploydb.resources.ModelRegistry
+import deploydb.models.Service
+
 class AppHelper {
     private StubAppRunner runner = null
     private Client jerseyClient = null
@@ -44,6 +47,15 @@ class AppHelper {
         }
     }
 
+    /**
+     *  Execute the {@link Closure} with a proper Service Registry
+     *
+     * @param c (required) Closure to execute 
+     */
+    void withServiceRegistry(Closure c) {
+        ModelRegistry<Service> serviceRegistry = this.runner.serviceRegistry
+        c.call(serviceRegistry)
+    }
 
     String processTemplate(String buffer, Map scope) {
         DefaultMustacheFactory mf = new DefaultMustacheFactory()

--- a/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
@@ -18,7 +18,7 @@ import org.hibernate.SessionFactory
 import org.hibernate.Transaction
 import org.hibernate.context.internal.ManagedSessionContext
 
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 import deploydb.models.Service
 
 class AppHelper {
@@ -53,8 +53,7 @@ class AppHelper {
      * @param c (required) Closure to execute 
      */
     void withServiceRegistry(Closure c) {
-        ModelRegistry<Service> serviceRegistry = this.runner.serviceRegistry
-        c.call(serviceRegistry)
+        c.call(this.runner.serviceRegistry)
     }
 
     String processTemplate(String buffer, Map scope) {
@@ -71,7 +70,7 @@ class AppHelper {
         if (this.jerseyClient == null) {
             ClientConfig clientConfig = new ClientConfig()
             clientConfig.connectorProvider(new ApacheConnectorProvider())
-            this.jerseyClient = ClientBuilder.newClient(clientConfig);
+            this.jerseyClient = ClientBuilder.newClient(clientConfig)
         }
         return this.jerseyClient
     }

--- a/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
@@ -1,6 +1,8 @@
 package deploydb.cucumber
 
 import deploydb.models.Artifact
+import deploydb.models.Service
+import deploydb.resources.ModelRegistry
 
 class ModelHelper {
 
@@ -16,4 +18,33 @@ class ModelHelper {
                              '1.0.2',
                              'http://example.com/maven/com.example.cucumber/cucumber-artifact/1.0.2/cucumber-artifact-1.0.2.jar')
     }    
+
+    /**
+     * Creates a sample service object
+     */ 
+    Service sampleService1(ModelRegistry<Service> serviceRegistry) {
+        Service service = new Service('Fun-as-a-Service',
+                                      [ 'com.github.lookout:foas',
+                                        'com.github.lookout.puppet:puppet-foas',
+                                        'com.github.lookout:puppet-mysql' ],
+                                      [ 'detoprod' ],
+                                      [ 'status-check',
+                                        'jenkins-smoke' ])
+        serviceRegistry.insert(service)
+        return service
+    }
+
+    /**
+     * Creates a sample service object
+     */ 
+    Service sampleService2(ModelRegistry<Service> serviceRegistry) {
+        Service service = new Service('Auditlog-as-a-Service',
+                                      [ 'com.github.lookout:alas',
+                                        'com.github.lookout.puppet:puppet-alas',
+                                        'com.github.lookout:puppet-mysql' ],
+                                      [ 'detoprod' ],
+                                      [ 'status-check',
+                                        'jenkins-smoke' ])
+        serviceRegistry.insert(service)
+        return service}
 }

--- a/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
@@ -2,7 +2,7 @@ package deploydb.cucumber
 
 import deploydb.models.Artifact
 import deploydb.models.Service
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 
 class ModelHelper {
 
@@ -30,7 +30,7 @@ class ModelHelper {
                                       [ 'detoprod' ],
                                       [ 'status-check',
                                         'jenkins-smoke' ])
-        serviceRegistry.insert(service)
+        serviceRegistry.put(service.name, service)
         return service
     }
 
@@ -45,6 +45,6 @@ class ModelHelper {
                                       [ 'detoprod' ],
                                       [ 'status-check',
                                         'jenkins-smoke' ])
-        serviceRegistry.insert(service)
+        serviceRegistry.put(service.name, service)
         return service}
 }

--- a/src/cucumber/groovy/deploydb/cucumber/StubAppRunner.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/StubAppRunner.groovy
@@ -23,6 +23,9 @@ import org.junit.runners.model.Statement
 import javax.annotation.Nullable
 import java.util.Enumeration
 
+import deploydb.resources.ModelRegistry
+import deploydb.models.Service
+
 /**
  * Class for running the Dropwizard app
  *
@@ -38,6 +41,7 @@ public class StubAppRunner<C extends Configuration> {
     private Environment environment
     private Server jettyServer
     private SessionFactory sessionFactory
+    private ModelRegistry<Service> serviceRegistry
 
     public StubAppRunner(Class<? extends Application<C>> applicationClass,
                         @Nullable String configPath,
@@ -79,6 +83,11 @@ public class StubAppRunner<C extends Configuration> {
                              * it's up and running
                              */
                             sessionFactory = application.sessionFactory
+
+                            /* Get a ModelRegistry<Service> out of the application once
+                             * it's up and running
+                             */
+                            serviceRegistry = application.serviceRegistry
 
                             /* We're running the DB migrations here to make sure we're running
                             * them in the same classloader environment as the DeployDB
@@ -137,13 +146,5 @@ public class StubAppRunner<C extends Configuration> {
 
     public <A extends Application<C>> A getApplication() {
         return (A) application
-    }
-
-    Environment getEnvironment() {
-        return environment
-    }
-
-    SessionFactory getSessionFactory() {
-        return sessionFactory
     }
 }

--- a/src/cucumber/groovy/deploydb/cucumber/StubAppRunner.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/StubAppRunner.groovy
@@ -23,7 +23,7 @@ import org.junit.runners.model.Statement
 import javax.annotation.Nullable
 import java.util.Enumeration
 
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 import deploydb.models.Service
 
 /**

--- a/src/cucumber/groovy/step_definitions/HttpSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/HttpSteps.groovy
@@ -26,8 +26,6 @@ When(~/^I PUT to "(.*?)" with:$/) { String path, String requestBody ->
 
 When(~/^I PUT to "(.*?)" with a (.*?) over ([1-9][0-9]*) characters$/) { String path, String var, int varSize ->
 
-    print "MVK : When I PUT, path = $path, var = $var, varSize = $varSize\n"
-
     // Create a randomString of size varSize+1
     String randomString = "test-".padRight(varSize+1, "a")
 

--- a/src/cucumber/groovy/step_definitions/ServiceSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/ServiceSteps.groovy
@@ -1,0 +1,18 @@
+import cucumber.api.*
+
+this.metaClass.mixin(cucumber.api.groovy.EN)
+
+import deploydb.models.Service
+import deploydb.resources.ModelRegistry
+
+Given(~/^there is an service$/) { ->
+    withServiceRegistry { ModelRegistry<Service> serviceRegistry ->
+        Service a = sampleService1(serviceRegistry)
+    }
+}
+Given(~/^there are services$/) { ->
+    withServiceRegistry { ModelRegistry<Service> serviceRegistry ->
+        Service s1 = sampleService1(serviceRegistry)
+        Service s2 = sampleService2(serviceRegistry)        
+    }
+}

--- a/src/cucumber/groovy/step_definitions/ServiceSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/ServiceSteps.groovy
@@ -3,7 +3,7 @@ import cucumber.api.*
 this.metaClass.mixin(cucumber.api.groovy.EN)
 
 import deploydb.models.Service
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 
 Given(~/^there is an service$/) { ->
     withServiceRegistry { ModelRegistry<Service> serviceRegistry ->

--- a/src/main/groovy/deploydb/DeployDBApp.groovy
+++ b/src/main/groovy/deploydb/DeployDBApp.groovy
@@ -26,6 +26,7 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
     private final ImmutableList models = ImmutableList.of(Artifact, Deployment)
     private final Logger logger = LoggerFactory.getLogger(DeployDBApp.class)
     private WebhookManager webhooks
+    private ModelRegistry<Service> serviceRegistry
 
     static void main(String[] args) throws Exception {
         new DeployDBApp().run(args)
@@ -86,6 +87,7 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
                     Environment environment) {
         final ArtifactDAO adao = new ArtifactDAO(hibernate.sessionFactory)
         final DeploymentDAO ddao = new DeploymentDAO(hibernate.sessionFactory)
+        serviceRegistry = new ModelRegistry<Service>(Service.class)
 
         environment.lifecycle().manage(webhooks)
 
@@ -95,5 +97,6 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
         environment.jersey().register(new RootResource())
         environment.jersey().register(new ArtifactResource(adao))
         environment.jersey().register(new DeploymentResource(ddao, adao))
+        environment.jersey().register(new ServiceResource(serviceRegistry))
     }
 }

--- a/src/main/groovy/deploydb/DeployDBApp.groovy
+++ b/src/main/groovy/deploydb/DeployDBApp.groovy
@@ -16,6 +16,7 @@ import org.joda.time.DateTimeZone
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import deploydb.registry.ModelRegistry
 import deploydb.resources.*
 import deploydb.health.*
 import deploydb.models.*

--- a/src/main/groovy/deploydb/models/Service.groovy
+++ b/src/main/groovy/deploydb/models/Service.groovy
@@ -40,4 +40,23 @@ class Service {
     @JsonProperty
     @Size(max=10)
     List<String> promotions
+
+    /**
+     * Empty constructor used by Jackson for object deserialization
+     */
+    Service() { }
+
+    /**
+     *  Constructor to be used by DeployDB internally. It accepts all
+     *  of the parameters
+     */
+    Service(String name,
+            List<String> artifacts,
+            List<String> pipelines,
+            List<String> promotions) {
+        this.name = name
+        this.artifacts = artifacts
+        this.pipelines = pipelines
+        this.promotions = promotions
+    }
 }

--- a/src/main/groovy/deploydb/registry/ModelRegistry.groovy
+++ b/src/main/groovy/deploydb/registry/ModelRegistry.groovy
@@ -1,19 +1,17 @@
-package deploydb.resources
+package deploydb.registry
 
-import java.io.File
-import java.util.*
-import java.io.IOException
-import javax.validation.Validation
-import javax.validation.Validator
-import io.dropwizard.jackson.Jackson
-import com.google.common.io.Resources;
-import io.dropwizard.configuration.ConfigurationFactory
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.google.common.io.Resources
+import groovy.transform.TypeChecked
+import io.dropwizard.configuration.ConfigurationFactory
+import io.dropwizard.jackson.Jackson
 import io.dropwizard.configuration.ConfigurationException
 import io.dropwizard.configuration.ConfigurationParsingException
 import io.dropwizard.configuration.ConfigurationValidationException
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import java.lang.IllegalArgumentException
+import javax.validation.Validation
+import javax.validation.Validator
 
 /**
  * Model Registry object
@@ -21,8 +19,9 @@ import java.lang.IllegalArgumentException
  * It creates the configuration driven model objects. The key for Model 
  * instances is String. Objects are stored in hashMap for later retrieval.
  */
+@TypeChecked
 class ModelRegistry<T> {
-    private final ConcurrentHashMap<String, T> modelTable
+    private ConcurrentHashMap<String, T> modelTable
     private final Validator validator
     private final ConfigurationFactory<T> factory
 
@@ -31,7 +30,7 @@ class ModelRegistry<T> {
     *
     * @param klass          the Model class
     */
-    public ModelRegistry(Class<T> klass) {
+    ModelRegistry(Class<T> klass) {
         this.validator = Validation.buildDefaultValidatorFactory().getValidator()
         this.factory = new ConfigurationFactory<>(klass,
                                                   validator,
@@ -44,9 +43,8 @@ class ModelRegistry<T> {
      *
      * @param model          the Model instance
      */
-    void insert(T model) throws IllegalArgumentException {
-        //if (model.name == null) throw IllegalArgumentException
-        modelTable.put(model.name, model)
+    void put(String name, T model) throws NullPointerException {
+        modelTable.put(name, model)
     }
     
     /**
@@ -54,19 +52,18 @@ class ModelRegistry<T> {
      *
      * @param File name, file is present in the resources directory
      */
-    T createFromFile(String filename)
+    T load(String filename)
         throws Exception, ConfigurationParsingException,
                ConfigurationValidationException {
         File inputFile = new File(Resources.getResource(filename).toURI())
         T model = factory.build(inputFile)
-        this.insert(model)
         return model
     }
 
     /**
      * Return list of all model objects
      */
-    List<T> getAllModels() {
+    List<T> getAll() {
         return new ArrayList<T>(modelTable.values())
     }
 
@@ -75,7 +72,7 @@ class ModelRegistry<T> {
      *
      * @param name The model instance's name (e.g. "fun-as-a-service")
      */
-    T getModelByName(String name) {
+    T get(String name) {
         return modelTable[name]
     }
 }

--- a/src/main/groovy/deploydb/resources/ModelRegistry.groovy
+++ b/src/main/groovy/deploydb/resources/ModelRegistry.groovy
@@ -1,0 +1,81 @@
+package deploydb.resources
+
+import java.io.File
+import java.util.*
+import java.io.IOException
+import javax.validation.Validation
+import javax.validation.Validator
+import io.dropwizard.jackson.Jackson
+import com.google.common.io.Resources;
+import io.dropwizard.configuration.ConfigurationFactory
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.dropwizard.configuration.ConfigurationException
+import io.dropwizard.configuration.ConfigurationParsingException
+import io.dropwizard.configuration.ConfigurationValidationException
+import java.util.concurrent.ConcurrentHashMap
+import java.lang.IllegalArgumentException
+
+/**
+ * Model Registry object
+ *
+ * It creates the configuration driven model objects. The key for Model 
+ * instances is String. Objects are stored in hashMap for later retrieval.
+ */
+class ModelRegistry<T> {
+    private final ConcurrentHashMap<String, T> modelTable
+    private final Validator validator
+    private final ConfigurationFactory<T> factory
+
+   /**
+    * Creates a new Model Registry for the given class.
+    *
+    * @param klass          the Model class
+    */
+    public ModelRegistry(Class<T> klass) {
+        this.validator = Validation.buildDefaultValidatorFactory().getValidator()
+        this.factory = new ConfigurationFactory<>(klass,
+                                                  validator,
+                                                  Jackson.newObjectMapper(), "")
+        this.modelTable = new ConcurrentHashMap<String, T>()
+    }
+
+    /**
+     * Insert an extant model in the table
+     *
+     * @param model          the Model instance
+     */
+    void insert(T model) throws IllegalArgumentException {
+        //if (model.name == null) throw IllegalArgumentException
+        modelTable.put(model.name, model)
+    }
+    
+    /**
+     * Instantiate a new Model object by parsing contents of the input file (T) 
+     *
+     * @param File name, file is present in the resources directory
+     */
+    T createFromFile(String filename)
+        throws Exception, ConfigurationParsingException,
+               ConfigurationValidationException {
+        File inputFile = new File(Resources.getResource(filename).toURI())
+        T model = factory.build(inputFile)
+        this.insert(model)
+        return model
+    }
+
+    /**
+     * Return list of all model objects
+     */
+    List<T> getAllModels() {
+        return new ArrayList<T>(modelTable.values())
+    }
+
+    /**
+     * Locate a Model by string name
+     *
+     * @param name The model instance's name (e.g. "fun-as-a-service")
+     */
+    T getModelByName(String name) {
+        return modelTable[name]
+    }
+}

--- a/src/main/groovy/deploydb/resources/ServiceResource.groovy
+++ b/src/main/groovy/deploydb/resources/ServiceResource.groovy
@@ -1,0 +1,69 @@
+package deploydb.resources
+
+import com.codahale.metrics.annotation.Timed
+import com.google.common.base.Optional
+import io.dropwizard.jersey.caching.CacheControl
+import io.dropwizard.jersey.params.*
+import io.dropwizard.hibernate.UnitOfWork
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+import javax.validation.Valid
+import javax.ws.rs.*
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.Response
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+import deploydb.resources.ModelRegistry
+import deploydb.models.Service
+
+/**
+ * ServiceResource class registered with JettyClient for servicing REST request
+ */
+@Path("/api/v1/services")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ServiceResource {
+    private final ModelRegistry<Service> serviceRegistry
+    private final Logger logger = LoggerFactory.getLogger(ServiceResource.class)
+
+    public ServiceResource(ModelRegistry<Service> serviceRegistry) {
+        this.serviceRegistry = serviceRegistry
+    }
+
+    /**
+     * Returns all Service objects
+     */
+    @GET
+    @UnitOfWork
+    @Timed(name = "get-requests")
+    public List<Service> getAll(@Context HttpHeaders headers) {
+        List<Service> serviceTable = this.serviceRegistry.getAllModels()
+
+        if (serviceTable.isEmpty()) {
+            throw new WebApplicationException(Response.Status.NOT_FOUND)
+        }
+        return serviceTable
+    }
+
+    /**
+     * Returns a Service object
+     */
+    @GET
+    @Path("{name}")
+    @UnitOfWork
+    @Timed(name = "get-requests")
+    public Service byName(@Context HttpHeaders headers,
+                          @PathParam("name") String serviceName) {
+        Service service = this.serviceRegistry.getModelByName(serviceName)
+
+        if (service == null) {
+            throw new WebApplicationException(Response.Status.NOT_FOUND)
+        }
+        return service
+    }
+}
+

--- a/src/main/groovy/deploydb/resources/ServiceResource.groovy
+++ b/src/main/groovy/deploydb/resources/ServiceResource.groovy
@@ -1,14 +1,12 @@
 package deploydb.resources
 
 import com.codahale.metrics.annotation.Timed
-import com.google.common.base.Optional
 import io.dropwizard.jersey.caching.CacheControl
 import io.dropwizard.jersey.params.*
 import io.dropwizard.hibernate.UnitOfWork
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import javax.validation.Valid
 import javax.ws.rs.*
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.HttpHeaders
@@ -17,7 +15,7 @@ import javax.ws.rs.core.Response
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 import deploydb.models.Service
 
 /**
@@ -40,8 +38,8 @@ public class ServiceResource {
     @GET
     @UnitOfWork
     @Timed(name = "get-requests")
-    public List<Service> getAll(@Context HttpHeaders headers) {
-        List<Service> serviceTable = this.serviceRegistry.getAllModels()
+    public List<Service> getAll() {
+        List<Service> serviceTable = this.serviceRegistry.getAll()
 
         if (serviceTable.isEmpty()) {
             throw new WebApplicationException(Response.Status.NOT_FOUND)
@@ -56,9 +54,8 @@ public class ServiceResource {
     @Path("{name}")
     @UnitOfWork
     @Timed(name = "get-requests")
-    public Service byName(@Context HttpHeaders headers,
-                          @PathParam("name") String serviceName) {
-        Service service = this.serviceRegistry.getModelByName(serviceName)
+    public Service byName(@PathParam("name") String serviceName) {
+        Service service = this.serviceRegistry.get(serviceName)
 
         if (service == null) {
             throw new WebApplicationException(Response.Status.NOT_FOUND)

--- a/src/test/groovy/deploydb/models/ServiceSpec.groovy
+++ b/src/test/groovy/deploydb/models/ServiceSpec.groovy
@@ -4,7 +4,7 @@ import spock.lang.*
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.dropwizard.configuration.ConfigurationParsingException
 import io.dropwizard.configuration.ConfigurationValidationException 
-import deploydb.resources.ModelRegistry
+import deploydb.registry.ModelRegistry
 import deploydb.models.Service
 
 class ServiceSpec extends Specification {
@@ -23,7 +23,8 @@ class ServiceWithArgsSpec extends Specification {
 
     def "Loading of valid service config file suceeds"() {
         given:
-        Service service = serviceRegistry.createFromFile("services/test-valid.yml")
+        Service service = serviceRegistry.load("services/test-valid.yml")
+        serviceRegistry.put(service.name, service)
 
         expect:
         service.name == "Fun as a Service"
@@ -33,12 +34,12 @@ class ServiceWithArgsSpec extends Specification {
         service.pipelines[0] == "devtoprod"
         service.promotions[0] == "status-check"
         service.promotions[1] == "jenkins-smoke"
-        serviceRegistry.getModelByName("Fun as a Service") == service
+        serviceRegistry.get("Fun as a Service") == service
     }
 
     def "Loading an empty service config file throws a null pointer exception"() {
         when:
-        Service service = serviceRegistry.createFromFile("services/test-empty.yml")
+        Service service = serviceRegistry.load("services/test-empty.yml")
 
         then:
         thrown(NullPointerException)
@@ -46,7 +47,7 @@ class ServiceWithArgsSpec extends Specification {
 
     def "Loading a malformed service config file throws throws a parsing exception"() {
         when:
-        Service service = serviceRegistry.createFromFile("services/test-malformed.yml")
+        Service service = serviceRegistry.load("services/test-malformed.yml")
 
         then:
         thrown(ConfigurationParsingException)
@@ -54,7 +55,7 @@ class ServiceWithArgsSpec extends Specification {
 
     def "Loading a invalid service config file throws throws a validation exception"() {
         when:
-        Service service = serviceRegistry.createFromFile("services/test-invalid.yml")
+        Service service = serviceRegistry.load("services/test-invalid.yml")
 
         then:
         thrown(ConfigurationValidationException)
@@ -63,7 +64,7 @@ class ServiceWithArgsSpec extends Specification {
     def "Inserting an empty object in Service Registry throws null pointer exception"() {
         when:
         Service service = new Service()
-        serviceRegistry.insert(service)
+        serviceRegistry.put(service.name, service)
 
         then:
         thrown(NullPointerException)

--- a/src/test/groovy/deploydb/models/ServiceSpec.groovy
+++ b/src/test/groovy/deploydb/models/ServiceSpec.groovy
@@ -1,22 +1,11 @@
 package deploydb.models
 
 import spock.lang.*
-
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.common.collect.Lists
-import com.google.common.io.Resources
-import io.dropwizard.jackson.Jackson
-import org.assertj.core.data.MapEntry
-import io.dropwizard.configuration.ConfigurationFactory
 import io.dropwizard.configuration.ConfigurationParsingException
-import io.dropwizard.configuration.ConfigurationValidationException
-
-import javax.validation.Validation
-import javax.validation.Validator
-import java.io.File
-import java.util.*
-import java.io.IOException
- 
+import io.dropwizard.configuration.ConfigurationValidationException 
+import deploydb.resources.ModelRegistry
+import deploydb.models.Service
 
 class ServiceSpec extends Specification {
     def "ensure Service object can be instantiated"() {
@@ -29,20 +18,12 @@ class ServiceSpec extends Specification {
 }
 
 class ServiceWithArgsSpec extends Specification {
-
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator()
-    private final ConfigurationFactory<Service> factory =
-            new ConfigurationFactory<>(Service.class, validator, Jackson.newObjectMapper(), "dw")
-
-    private File getFile(String filename) {
-        ClassLoader classLoader = getClass().getClassLoader()
-        return new File(classLoader.getResource(filename).toURI())
-    }
+    private final ModelRegistry<Service> serviceRegistry =
+            new ModelRegistry<Service>(Service.class)
 
     def "Loading of valid service config file suceeds"() {
         given:
-        File validFile = getFile("services/test-valid.yml")
-        Service service = factory.build(validFile)
+        Service service = serviceRegistry.createFromFile("services/test-valid.yml")
 
         expect:
         service.name == "Fun as a Service"
@@ -52,38 +33,39 @@ class ServiceWithArgsSpec extends Specification {
         service.pipelines[0] == "devtoprod"
         service.promotions[0] == "status-check"
         service.promotions[1] == "jenkins-smoke"
+        serviceRegistry.getModelByName("Fun as a Service") == service
     }
 
     def "Loading an empty service config file throws a null pointer exception"() {
-        given:
-        File emptyFile = getFile("services/test-empty.yml")
-        
         when:
-        Service service = factory.build(emptyFile)
+        Service service = serviceRegistry.createFromFile("services/test-empty.yml")
 
         then:
         thrown(NullPointerException)
     }
 
     def "Loading a malformed service config file throws throws a parsing exception"() {
-        given:
-        File malformedFile = getFile("services/test-malformed.yml")
-        
         when:
-        Service service = factory.build(malformedFile)
+        Service service = serviceRegistry.createFromFile("services/test-malformed.yml")
 
         then:
         thrown(ConfigurationParsingException)
     }
 
     def "Loading a invalid service config file throws throws a validation exception"() {
-        given:
-        File invalidFile = getFile("services/test-invalid.yml")
-        
         when:
-        Service service = factory.build(invalidFile)
+        Service service = serviceRegistry.createFromFile("services/test-invalid.yml")
 
         then:
         thrown(ConfigurationValidationException)
+    }
+
+    def "Inserting an empty object in Service Registry throws null pointer exception"() {
+        when:
+        Service service = new Service()
+        serviceRegistry.insert(service)
+
+        then:
+        thrown(NullPointerException)
     }
 }


### PR DESCRIPTION
Added a ModelRegistry to manage config driven data objects (e.g. Service)
in the memory. Added an REST API to return all or a specific by name
Service instance. Added cucumber and spock unit tests.

Fixes #43