### PR TITLE
Setup flyway object in the deploydb app

### DIFF
--- a/deploydb.example.yml
+++ b/deploydb.example.yml
@@ -1,7 +1,7 @@
 database:
   driverClass: org.h2.Driver
   user: nobody
-  url: "jdbc:h2:mem:"
+  url: "jdbc:h2:mem"
 
 # DeployDB base configuration directory (cannonical path)
 # YAML configuration files for models - services, environments, pipelines,

--- a/src/main/groovy/deploydb/DeployDBApp.groovy
+++ b/src/main/groovy/deploydb/DeployDBApp.groovy
@@ -11,6 +11,7 @@ import io.dropwizard.hibernate.SessionFactoryFactory
 import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
 import io.dropwizard.views.ViewBundle
+import org.flywaydb.core.Flyway
 import org.hibernate.SessionFactory
 import org.joda.time.DateTimeZone
 import org.slf4j.Logger
@@ -88,10 +89,18 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
     @Override
     public void run(DeployDBConfiguration configuration,
                     Environment environment) {
+        /* Execute migrations */
+        Flyway flyway = new Flyway()
+        flyway.setDataSource(configuration.getDataSourceFactory().getUrl(),
+                             configuration.getDataSourceFactory().getUser(),
+                             configuration.getDataSourceFactory().getPassword());
+        flyway.clean()
+        flyway.migrate()
+
         /**
          * Initialize the workflow object
          */
-        workFlow.initializeDb()
+        workFlow.initializeDao()
         workFlow.initializeRegistry()
 
         /**

--- a/src/main/groovy/deploydb/WebhookManager.groovy
+++ b/src/main/groovy/deploydb/WebhookManager.groovy
@@ -19,7 +19,7 @@ class WebhookManager implements Managed {
     private SequentialHookRunner runner
     private InMemoryQueue queue = new InMemoryQueue()
     private final Logger logger = LoggerFactory.getLogger(WebhookManager.class)
-    private Webhook webhook
+    private Webhook webhook = null
 
     /*
      * This function will be used to fetch different webhooks types
@@ -32,11 +32,6 @@ class WebhookManager implements Managed {
 
     WebhookManager( ) {
         runner = new SequentialHookRunner(this.queue)
-
-        /**
-         * Initialize the webhook object
-         */
-        webhook = new Webhook()
 
         runnerThread = new Thread({
             runner.run()
@@ -71,7 +66,10 @@ class WebhookManager implements Managed {
             eventUrlList = environmentWebhook.deployment ?
                     getMemberOfObject(environmentWebhook.deployment, eventType) : []
         }
-        eventUrlList += webhook.deployment ? getMemberOfObject(webhook.deployment, eventType) : []
+        if (webhook != null) {
+            eventUrlList += webhook.deployment ?
+                    getMemberOfObject(webhook.deployment, eventType) : []
+        }
 
         /*
          * If the URL list is non empty, iterate over URLs and send the webhook request

--- a/src/main/groovy/deploydb/WorkFlow.groovy
+++ b/src/main/groovy/deploydb/WorkFlow.groovy
@@ -29,7 +29,7 @@ public class WorkFlow {
         this.deployDBApp = app
     }
 
-    void initializeDb() {
+    void initializeDao() {
         /**
          * Instantiate DAO objects
          */
@@ -99,7 +99,7 @@ public class WorkFlow {
                 new registry.ModelRegistry<models.pipeline.Pipeline>()
         registry.ModelRegistry<models.Service> tmpServiceRegistry =
                 new registry.ModelRegistry<models.Service>()
-        models.Webhook.Webhook tmpWebhook
+        models.Webhook.Webhook tmpWebhook = null
 
         /* Load promotions */
         String promotionsDirName = baseConfigDirName + "/promotions"


### PR DESCRIPTION
References #90 

Client Output:
1. Create artifact:
thq-m-mkelk01:deploydb-0217 mkelkar$ curl -X POST -H  "Content-Type: application/json" http://52.11.218.78:8080/api/artifacts -d '{"group" : "basic.group.1", "name": "bg1", "version" : "1.2.3.4", "sourceUrl" : "http://example.com/cucumber.jar"}'
{"id":1,"createdAt":"2015-03-10T15:24:16.199Z","group":"basic.group.1","name":"bg1","version":"1.2.3.4","sourceUrl":"http://example.com/cucumber.jar"}

2. Get all deployments
thq-m-mkelk01:deploydb-0217 mkelkar$ curl -X GET http://52.11.218.78:8080/api/deployments
[{"id":1,"createdAt":"2015-03-10T15:24:16.223Z","artifact":{"id":1,"createdAt":"2015-03-10T15:24:16.199Z","group":"basic.group.1","name":"bg1","version":"1.2.3.4","sourceUrl":"http://example.com/cucumber.jar"},"status":"CREATED","environment":"basicEnv","service":"basicServ","promotions":[{"id":1,"createdAt":"2015-03-10T15:24:16.229Z","status":"NOT_STARTED","infoUrl":null,"promotion":"basicPromo"}]}]thq-m-mkelk01:deploydb-0217 mkelkar$ 


AWS Output:
INFO  [2015-03-10 15:19:58,368] deploydb.DeployDBApp: Loading models from directory: /home/ec2-user/deploydb/config
INFO  [2015-03-10 15:19:58,758] io.dropwizard.server.ServerFactory: Starting deploydb
INFO  [2015-03-10 15:19:58,826] deploydb.WebhookManager: Thread[WebhookManager Thread,5,main] started
INFO  [2015-03-10 15:19:59,931] io.dropwizard.jersey.DropwizardResourceConfig: The following paths were found for the configured resources:

INFO  [2015-03-10 15:19:59,957] org.eclipse.jetty.server.handler.ContextHandler: Started i.d.j.MutableServletContextHandler@10a5930c{/,null,AVAILABLE}
INFO  [2015-03-10 15:19:59,968] io.dropwizard.setup.AdminEnvironment: tasks = 

    POST    /tasks/gc (io.dropwizard.servlets.tasks.GarbageCollectionTask)

INFO  [2015-03-10 15:19:59,973] org.eclipse.jetty.server.handler.ContextHandler: Started i.d.j.MutableServletContextHandler@6d545c1a{/,null,AVAILABLE}
INFO  [2015-03-10 15:19:59,989] org.eclipse.jetty.server.ServerConnector: Started application@55117a5{HTTP/1.1}{0.0.0.0:8080}
INFO  [2015-03-10 15:19:59,989] org.eclipse.jetty.server.ServerConnector: Started admin@ee7545d{HTTP/1.1}{0.0.0.0:8081}
INFO  [2015-03-10 15:19:59,989] org.eclipse.jetty.server.Server: Started @6858ms
DEBUG [2015-03-10 15:24:16,253] org.hibernate.SQL: /* insert deploydb.models.Artifact */ insert into artifacts (id, createdAt, deletedAt, groupName, name, sourceUrl, version) values (null, ?, ?, ?, ?, ?, ?)
DEBUG [2015-03-10 15:24:16,268] org.hibernate.SQL: /* insert deploydb.models.Flow */ insert into flows (id, createdAt, deletedAt, artifactId, service, status) values (null, ?, ?, ?, ?, ?)
DEBUG [2015-03-10 15:24:16,271] org.hibernate.SQL: /* insert deploydb.models.Deployment */ insert into deployments (id, createdAt, deletedAt, artifactId, environment, flowId, service, status) values (null, ?, ?, ?, ?, ?, ?, ?)
DEBUG [2015-03-10 15:24:16,272] org.hibernate.SQL: /* insert deploydb.models.PromotionResult */ insert into promotionResults (id, createdAt, deletedAt, deploymentId, infoUrl, promotion, status) values (null, ?, ?, ?, ?, ?, ?)
DEBUG [2015-03-10 15:24:16,469] org.hibernate.SQL: /* update deploydb.models.Deployment */ update deployments set createdAt=?, deletedAt=?, environment=?, flowId=?, service=?, status=? where id=?
INFO  [2015-03-10 15:24:16,473] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    60849 nanoseconds spent acquiring 1 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    922473 nanoseconds spent preparing 5 JDBC statements;
    3121014 nanoseconds spent executing 5 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    26298394 nanoseconds spent executing 1 flushes (flushing a total of 4 entities and 2 collections);
    0 nanoseconds spent executing 0 partial-flushes (flushing a total of 0 entities and 0 collections)
}
209.66.94.66 - - [10/Mar/2015:15:24:16 +0000] "POST /api/artifacts HTTP/1.1" 201 150 "-" "curl/7.37.1" 432
DEBUG [2015-03-10 15:25:09,436] org.hibernate.SQL: /* criteria query */ select this_.id as id1_1_4_, this_.createdAt as createdA2_1_4_, this_.deletedAt as deletedA3_1_4_, this_.artifactId as artifact7_1_4_, this_.environment as environm4_1_4_, this_.flowId as flowId8_1_4_, this_.service as service5_1_4_, this_.status as status6_1_4_, artifact2_.id as id1_0_0_, artifact2_.createdAt as createdA2_0_0_, artifact2_.deletedAt as deletedA3_0_0_, artifact2_.groupName as groupNam4_0_0_, artifact2_.name as name5_0_0_, artifact2_.sourceUrl as sourceUr6_0_0_, artifact2_.version as version7_0_0_, flow3_.id as id1_2_1_, flow3_.createdAt as createdA2_2_1_, flow3_.deletedAt as deletedA3_2_1_, flow3_.artifactId as artifact6_2_1_, flow3_.service as service4_2_1_, flow3_.status as status5_2_1_, artifact4_.id as id1_0_2_, artifact4_.createdAt as createdA2_0_2_, artifact4_.deletedAt as deletedA3_0_2_, artifact4_.groupName as groupNam4_0_2_, artifact4_.name as name5_0_2_, artifact4_.sourceUrl as sourceUr6_0_2_, artifact4_.version as version7_0_2_, promotionr5_.deploymentId as deployme7_1_6_, promotionr5_.id as id1_3_6_, promotionr5_.id as id1_3_3_, promotionr5_.createdAt as createdA2_3_3_, promotionr5_.deletedAt as deletedA3_3_3_, promotionr5_.deploymentId as deployme7_3_3_, promotionr5_.infoUrl as infoUrl4_3_3_, promotionr5_.promotion as promotio5_3_3_, promotionr5_.status as status6_3_3_ from deployments this_ inner join artifacts artifact2_ on this_.artifactId=artifact2_.id left outer join flows flow3_ on this_.flowId=flow3_.id left outer join artifacts artifact4_ on flow3_.artifactId=artifact4_.id left outer join promotionResults promotionr5_ on this_.id=promotionr5_.deploymentId order by this_.createdAt desc, promotionr5_.id limit ?
DEBUG [2015-03-10 15:25:09,453] org.hibernate.SQL: select deployment0_.flowId as flowId8_2_0_, deployment0_.id as id1_1_0_, deployment0_.id as id1_1_1_, deployment0_.createdAt as createdA2_1_1_, deployment0_.deletedAt as deletedA3_1_1_, deployment0_.artifactId as artifact7_1_1_, deployment0_.environment as environm4_1_1_, deployment0_.flowId as flowId8_1_1_, deployment0_.service as service5_1_1_, deployment0_.status as status6_1_1_, artifact1_.id as id1_0_2_, artifact1_.createdAt as createdA2_0_2_, artifact1_.deletedAt as deletedA3_0_2_, artifact1_.groupName as groupNam4_0_2_, artifact1_.name as name5_0_2_, artifact1_.sourceUrl as sourceUr6_0_2_, artifact1_.version as version7_0_2_ from deployments deployment0_ inner join artifacts artifact1_ on deployment0_.artifactId=artifact1_.id where deployment0_.flowId=? order by deployment0_.id
INFO  [2015-03-10 15:25:09,470] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {
    41986 nanoseconds spent acquiring 1 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    3334447 nanoseconds spent preparing 2 JDBC statements;
    528957 nanoseconds spent executing 2 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    608592 nanoseconds spent executing 1 flushes (flushing a total of 4 entities and 2 collections);
    33241 nanoseconds spent executing 1 partial-flushes (flushing a total of 0 entities and 0 collections)
}
209.66.94.66 - - [10/Mar/2015:15:25:09 +0000] "GET /api/deployments HTTP/1.1" 200 403 "-" "curl/7.37.1" 77

