### PR TITLE
Fix V2,4-6 migrations to work against MySQL

### DIFF
--- a/src/main/groovy/db/migration/V2__artifacts_versions.groovy
+++ b/src/main/groovy/db/migration/V2__artifacts_versions.groovy
@@ -38,7 +38,7 @@ class V2__artifacts_versions extends DeployDBMigration {
                     version VARCHAR(255) NOT NULL,
                     sourceUrl TEXT,
                     createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
-                    deletedAt TIMESTAMP DEFAULT NULL
+                    deletedAt TIMESTAMP NULL
                 );
         """
 

--- a/src/main/groovy/db/migration/V4__create_deployments_table.groovy
+++ b/src/main/groovy/db/migration/V4__create_deployments_table.groovy
@@ -37,7 +37,7 @@ class V4__create_deployments_table extends DeployDBMigration {
                 status INT(11) NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
-                deletedAt TIMESTAMP DEFAULT NULL,
+                deletedAt TIMESTAMP NULL,
 
                 PRIMARY KEY (id)
             );

--- a/src/main/groovy/db/migration/V5__create_flows_table.groovy
+++ b/src/main/groovy/db/migration/V5__create_flows_table.groovy
@@ -36,7 +36,7 @@ class V5__create_flows_table extends DeployDBMigration {
                 service TEXT NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
-                deletedAt TIMESTAMP DEFAULT NULL,
+                deletedAt TIMESTAMP NULL,
 
                 PRIMARY KEY (id)
             );

--- a/src/main/groovy/db/migration/V6__create_promotion_results_table.groovy
+++ b/src/main/groovy/db/migration/V6__create_promotion_results_table.groovy
@@ -38,7 +38,7 @@ class V6__create_promotion_results_table extends DeployDBMigration {
                 deploymentId BIGINT(11) NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
-                deletedAt TIMESTAMP DEFAULT NULL,
+                deletedAt TIMESTAMP NULL,
 
                 PRIMARY KEY (id),
                 FOREIGN KEY (deploymentId) REFERENCES deployments(id)


### PR DESCRIPTION
While deploying against MySQL I came across migration stack trace errors due to the incorrect DDL SQL used in the Flyway migrations. See link for details:
https://gist.github.com/mbbx6spp/a44d55530e998cf84a82

The fix is simple, `DEFAULT NULL` is not recognized as valid [DDL](http://en.wikipedia.org/wiki/Data_definition_language) for MySQL (DDL across databases is a clusterduck) so I am just explicitly stating we want `deletedAt` fields to be `NULL`-able. By default in MySQL it would be `NULL`-able so I could have omitted it completely but this may not be a valid assumption for other databases.

_Note: I will create another issue which I haven't resolved yet to consider (since DeployDB is open source and thus wide adoption may be a goal) which target databases would be supported since these schema migrations are at complete odds with recognized/valid PostgreSQL DDL outside of this change, not `BIGINT(11)` is meaningless; it is ignored by H2 and MySQL but is invalid in PostgreSQL, since `BIGINT` is 8 byte integer regardless of what is in the brackets._