### PR TITLE
Remove integer type lengths in schema migrations

### DIFF
--- a/src/main/groovy/db/migration/V1__create_artifacts_table.groovy
+++ b/src/main/groovy/db/migration/V1__create_artifacts_table.groovy
@@ -30,7 +30,7 @@ class V1__create_artifacts_table extends DeployDBMigration {
          */
         commands += """
             CREATE TABLE artifacts (
-                id BIGINT(11) AUTO_INCREMENT,
+                id BIGINT AUTO_INCREMENT,
 
                 groupName TEXT NOT NULL,
 

--- a/src/main/groovy/db/migration/V4__create_deployments_table.groovy
+++ b/src/main/groovy/db/migration/V4__create_deployments_table.groovy
@@ -30,11 +30,11 @@ class V4__create_deployments_table extends DeployDBMigration {
          */
         commands += """
             CREATE TABLE deployments (
-                id BIGINT(11) AUTO_INCREMENT,
+                id BIGINT AUTO_INCREMENT,
 
-                artifactId BIGINT(11) NOT NULL,
+                artifactId BIGINT NOT NULL,
                 environment VARCHAR(8192) NOT NULL,
-                status INT(11) NOT NULL,
+                status INT NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                 deletedAt TIMESTAMP NULL,

--- a/src/main/groovy/db/migration/V5__create_flows_table.groovy
+++ b/src/main/groovy/db/migration/V5__create_flows_table.groovy
@@ -30,9 +30,9 @@ class V5__create_flows_table extends DeployDBMigration {
          */
         commands += """
             CREATE TABLE flows (
-                id BIGINT(11) AUTO_INCREMENT,
+                id BIGINT AUTO_INCREMENT,
 
-                artifactId BIGINT(11) NOT NULL,
+                artifactId BIGINT NOT NULL,
                 service TEXT NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
@@ -44,7 +44,7 @@ class V5__create_flows_table extends DeployDBMigration {
 
         /* Add flowId to deployments table */
         commands += """
-            ALTER TABLE deployments ADD COLUMN flowId BIGINT(11);
+            ALTER TABLE deployments ADD COLUMN flowId BIGINT;
         """
 
         /* Add foreign key */

--- a/src/main/groovy/db/migration/V6__create_promotion_results_table.groovy
+++ b/src/main/groovy/db/migration/V6__create_promotion_results_table.groovy
@@ -30,12 +30,12 @@ class V6__create_promotion_results_table extends DeployDBMigration {
          */
         commands += """
             CREATE TABLE promotionResults (
-                id BIGINT(11) AUTO_INCREMENT,
+                id BIGINT AUTO_INCREMENT,
 
                 promotion VARCHAR(8192) NOT NULL,
-                status INT(11) NOT NULL,
+                status INT NOT NULL,
                 infoUrl TEXT,
-                deploymentId BIGINT(11) NOT NULL,
+                deploymentId BIGINT NOT NULL,
 
                 createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                 deletedAt TIMESTAMP NULL,

--- a/src/main/groovy/db/migration/V7__add_status_to_flows.groovy
+++ b/src/main/groovy/db/migration/V7__add_status_to_flows.groovy
@@ -29,7 +29,7 @@ class V7__add_status_to_flows extends DeployDBMigration {
          * Add status column to flows table
          */
         commands += """
-            ALTER TABLE flows ADD COLUMN status INT(11) NOT NULL;
+            ALTER TABLE flows ADD COLUMN status INT NOT NULL;
         """
 
         return commands


### PR DESCRIPTION
Lengths for integer types in SQL DDL statements are unnecessary and
meaningless. What is worse is it gives the reader/maintainer a false
sense of storage length. In addition removing these mostly ignored
length suffices from integer tyes in DDL we remove one more barrier
to being DDL conformant to supporting PostgreSQL if we want to though
there are still problems with `AUTO_INCREMENT`.

To demonstrate that these lengths are useless please see the integer
types from the MySQL v5.5 documentation:
https://dev.mysql.com/doc/refman/5.5/en/integer-types.html

And you can see a sanity check I documented in this Gist:
https://gist.github.com/mbbx6spp/77fc5c2c386ee6b3ef5c

The Travis CI tests will validate that this works against H2 and the following
output should show it is working against MySQL v5.5 which presumably
is a targeted production database to be supported by the project:

```
$ mysql -u root -e "drop database deploydb; create database deploydb;"
$ grep -A4 "^database:" deploydb.yml
database:
  driverClass: com.mysql.jdbc.Driver
  user: deploydb
  password: deploydb
  url: "jdbc:mysql://localhost/deploydb"
$ java -jar build/libs/deploydb-0.1.0-all.jar db migrate deploydb.yml
INFO  [2015-03-29 22:27:41,897] org.flywaydb.core.internal.dbsupport.DbSupportFactory: Database: jdbc:mysql://localhost/deploydb (MySQL 5.5)
INFO  [2015-03-29 22:27:41,917] org.flywaydb.core.internal.metadatatable.MetaDataTableImpl: Creating Metadata table: `deploydb`.`schema_version`
INFO  [2015-03-29 22:27:42,108] org.flywaydb.core.internal.command.DbMigrate: Current version of schema `deploydb`: << Empty Schema >>
INFO  [2015-03-29 22:27:42,109] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 1
INFO  [2015-03-29 22:27:42,136] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE TABLE artifacts (
                id BIGINT AUTO_INCREMENT,

                groupName TEXT NOT NULL,

                name TEXT NOT NULL,

                PRIMARY KEY (id)
            );
        
INFO  [2015-03-29 22:27:42,164] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 2
INFO  [2015-03-29 22:27:42,165] db.migration.DeployDBMigration: Preparing statement for: 
            ALTER TABLE artifacts
                ADD COLUMN (
                    version VARCHAR(255) NOT NULL,
                    sourceUrl TEXT,
                    createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                    deletedAt TIMESTAMP NULL
                );
        
INFO  [2015-03-29 22:27:42,180] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE INDEX version_index ON artifacts(version);
        
INFO  [2015-03-29 22:27:42,202] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 3
INFO  [2015-03-29 22:27:42,216] db.migration.DeployDBMigration: Preparing statement for: 
                ALTER TABLE artifacts MODIFY COLUMN groupName VARCHAR(8192);
            
INFO  [2015-03-29 22:27:42,229] db.migration.DeployDBMigration: Preparing statement for: 
                ALTER TABLE artifacts MODIFY COLUMN name VARCHAR(8192);
            
INFO  [2015-03-29 22:27:42,242] db.migration.DeployDBMigration: Preparing statement for: 
                DROP INDEX version_index ON artifacts;
            
INFO  [2015-03-29 22:27:42,250] db.migration.DeployDBMigration: Preparing statement for: 
                CREATE UNIQUE INDEX artifactveridx ON artifacts (groupName(50), name(50), version(50));
            
INFO  [2015-03-29 22:27:42,269] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 4
INFO  [2015-03-29 22:27:42,271] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE TABLE deployments (
                id BIGINT AUTO_INCREMENT,

                artifactId BIGINT NOT NULL,
                environment VARCHAR(8192) NOT NULL,
                status INT NOT NULL,

                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                deletedAt TIMESTAMP NULL,

                PRIMARY KEY (id)
            );
        
INFO  [2015-03-29 22:27:42,280] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE INDEX deploys_by_artifact ON deployments(artifactId);
        
INFO  [2015-03-29 22:27:42,297] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 5
INFO  [2015-03-29 22:27:42,298] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE TABLE flows (
                id BIGINT AUTO_INCREMENT,

                artifactId BIGINT NOT NULL,
                service TEXT NOT NULL,

                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                deletedAt TIMESTAMP NULL,

                PRIMARY KEY (id)
            );
        
INFO  [2015-03-29 22:27:42,303] db.migration.DeployDBMigration: Preparing statement for: 
            ALTER TABLE deployments ADD COLUMN flowId BIGINT;
        
INFO  [2015-03-29 22:27:42,317] db.migration.DeployDBMigration: Preparing statement for: 
            ALTER TABLE deployments ADD FOREIGN KEY (flowId) REFERENCES flows(id);
        
INFO  [2015-03-29 22:27:42,339] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 6
INFO  [2015-03-29 22:27:42,340] db.migration.DeployDBMigration: Preparing statement for: 
            CREATE TABLE promotionResults (
                id BIGINT AUTO_INCREMENT,

                promotion VARCHAR(8192) NOT NULL,
                status INT NOT NULL,
                infoUrl TEXT,
                deploymentId BIGINT NOT NULL,

                createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),
                deletedAt TIMESTAMP NULL,

                PRIMARY KEY (id),
                FOREIGN KEY (deploymentId) REFERENCES deployments(id)
            );
        
INFO  [2015-03-29 22:27:42,346] db.migration.DeployDBMigration: Preparing statement for: 
            ALTER TABLE deployments ADD COLUMN service VARCHAR(8192) NOT NULL;
        
INFO  [2015-03-29 22:27:42,369] org.flywaydb.core.internal.command.DbMigrate: Migrating schema `deploydb` to version 7
INFO  [2015-03-29 22:27:42,370] db.migration.DeployDBMigration: Preparing statement for: 
            ALTER TABLE flows ADD COLUMN status INT NOT NULL;
        
INFO  [2015-03-29 22:27:42,391] org.flywaydb.core.internal.command.DbMigrate: Successfully applied 7 migrations to schema `deploydb` (execution time 00:00.475s).

```

Note: There are still issues with PostgreSQL migration as tested against 9.4
locally though this is almost certainly true of other versions due to it's non-
support of `AUTO_INCREMENT` (a MySQL-ism) keyword.