### PR TITLE
Update running doc with correct JAR path

### DIFF
--- a/src/asciidoc/running.ad
+++ b/src/asciidoc/running.ad
@@ -11,13 +11,13 @@ To test the example application on localhost run the following commands.
 * To setup the h2 database run (stored in current directory as deploydb.example.db).
 
 ----
-  java -jar build/libs/deploydb-0.1.0.jar db migrate deploydb.example.yml
+  java -jar build/libs/deploydb-0.1.0-all.jar db migrate deploydb.example.yml
 ----
 
 * To run the server (it reads configuration from config/ directory).
 
 ----
-  java -jar build/libs/deploydb-0.1.0.jar server example.yml
+  java -jar build/libs/deploydb-0.1.0-all.jar server example.yml
 ----
 
 * To create artifact (That triggers deployment create)


### PR DESCRIPTION
Update path of JAR in running documentation as the current mentioned JAR path does not have a `Main-Class` attribute in the `META-INF/MANIFEST.MF` entry:

```
no main manifest attribute, in build/libs/deploydb-0.1.0.jar
```