### PR TITLE
Fix Gradle JDBC driver dependencies to be runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ dependencies {
     /* Webhook support */
     compile 'com.github.lookout:whoas:0.2.0'
 
-    compile withSources('com.h2database:h2:1.3.+')
     compile withSources('joda-time:joda-time:2.6+')
-    compile 'mysql:mysql-connector-java:5.1.+'
+    runtime 'mysql:mysql-connector-java:5.1.+'
+    runtime withSources('com.h2database:h2:1.3.+')
 
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
     testCompile 'cglib:cglib-nodep:2.2.+'


### PR DESCRIPTION
It is generally bad practice to define JDBC or other dynamically loaded with
standard API to be required as compile time dependencies as the purpose of
these is to load them in at runtime and only rely on their generic API. When
you define a dependency like this as compile scope instead of runtime you
open yourself up to developers using MySQL, or H2 specific APIs without
realizing this dependency because the build will never catch it.