### PR TITLE
Added support for LDAP authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,10 @@ dependencies {
     /* Webhook support */
     compile 'com.github.lookout:whoas:0.2.0'
 
+    /* Java Date & Time support */
     compile withSources('joda-time:joda-time:2.6+')
+
+    /* DB support */
     runtime 'mysql:mysql-connector-java:5.1.+'
     runtime withSources('com.h2database:h2:1.3.+')
     runtime 'org.postgresql:postgresql:9.3-1103-jdbc41'
@@ -60,6 +63,8 @@ dependencies {
     testCompile 'cglib:cglib-nodep:2.2.+'
 
     cucumberCompile 'info.cukes:cucumber-groovy:1.2.+'
+
+    /* Include unboundid sdk for in-memory ldap test server */
     cucumberCompile 'com.unboundid:unboundid-ldapsdk:2.3.8'
 
     codenarc(

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     [
      'dropwizard-core',
+     'dropwizard-auth',
      'dropwizard-assets',
      'dropwizard-jersey',
      'dropwizard-hibernate',
@@ -59,6 +60,7 @@ dependencies {
     testCompile 'cglib:cglib-nodep:2.2.+'
 
     cucumberCompile 'info.cukes:cucumber-groovy:1.2.+'
+    cucumberCompile 'com.unboundid:unboundid-ldapsdk:2.3.8'
 
     codenarc(
             "org.codenarc:CodeNarc:0.22",
@@ -70,7 +72,6 @@ dependencies {
 repositories {
     jcenter()
     mavenCentral()
-
     maven { url 'http://dl.bintray.com/lookout/systems' }
 }
 ////////////////////////////////////////////////////////////////////////////////

--- a/deploydb.h2.cucumber.yml
+++ b/deploydb.h2.cucumber.yml
@@ -23,3 +23,15 @@ logging:
       threshold: ALL
       archive: false
       timeZone: UTC
+
+ldap:
+  uri: ldap://localhost:10389
+  cachePolicy: maximumSize=10000, expireAfterWrite=10m
+  userFilter: ou=people,dc=yourcompany,dc=com
+  groupFilter: ou=groups,dc=yourcompany,dc=com
+  userNameAttribute: cn
+  groupNameAttribute: cn
+  groupMembershipAttribute: memberUid
+  groupClassName: groupOfUniqueNames
+  connectTimeout: 500ms
+  readTimeout: 500ms

--- a/docs/html5/auth.html
+++ b/docs/html5/auth.html
@@ -506,15 +506,15 @@ table.CodeRay td.code>pre{padding:0}
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-<li><a href="#_basic_authentication_for_administrator">Basic Authentication for Administrator</a></li>
-<li><a href="#_ldap_authentication">LDAP Authentication</a></li>
+<li><a href="#_basic_http_authentication_for_administrator">Basic HTTP Authentication for Administrator</a></li>
+<li><a href="#_ldap_authentication_for_users">LDAP Authentication for Users</a></li>
 <li><a href="#_security">Security</a></li>
 </ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
-<h2 id="_basic_authentication_for_administrator"><a class="anchor" href="#_basic_authentication_for_administrator"></a>Basic Authentication for Administrator</h2>
+<h2 id="_basic_http_authentication_for_administrator"><a class="anchor" href="#_basic_http_authentication_for_administrator"></a>Basic HTTP Authentication for Administrator</h2>
 <div class="sectionbody">
 <div class="ulist">
 <ul>
@@ -535,16 +535,17 @@ over the admin port.</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_ldap_authentication"><a class="anchor" href="#_ldap_authentication"></a>LDAP Authentication</h2>
+<h2 id="_ldap_authentication_for_users"><a class="anchor" href="#_ldap_authentication_for_users"></a>LDAP Authentication for Users</h2>
 <div class="sectionbody">
 <div class="ulist">
 <ul>
 <li>
-<p>LDAP Authentication can be enabled on REST APIs using following
-<a href="https://github.com/yammer/dropwizard-auth-ldap/blob/master/README.md#configuration">configuration</a></p>
+<p>LDAP Authentication can be enabled on REST APIs using following configuration</p>
 </li>
 <li>
-<p>The cache-policy should be configured to improve application&#8217;s performance.</p>
+<p>The cache-policy should be configured to improve application&#8217;s performance. More details can be found at
+<a href="http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html" class="bare">http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html</a>
+[CacheBuilderSpec]</p>
 </li>
 </ul>
 </div>
@@ -552,20 +553,17 @@ over the admin port.</p>
 <div class="title">deploydb.launch.yml</div>
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="yaml"><span class="key">ldap</span>:
-  <span class="key">uri</span>: <span class="string"><span class="content">ldaps://myldap.com:636</span></span>
+  <span class="key">uri</span>: <span class="string"><span class="content">ldap://server.lookout.com:10389</span></span>
   <span class="comment"># Cache 10000 credentials for at least 10 minutes</span>
   <span class="key">cachePolicy</span>: <span class="string"><span class="content">maximumSize=10000, expireAfterWrite=10m</span></span>
   <span class="key">userFilter</span>: <span class="string"><span class="content">ou=people,dc=yourcompany,dc=com</span></span>
   <span class="key">groupFilter</span>: <span class="string"><span class="content">ou=groups,dc=yourcompany,dc=com</span></span>
   <span class="key">userNameAttribute</span>: <span class="string"><span class="content">cn</span></span>
   <span class="key">groupNameAttribute</span>: <span class="string"><span class="content">cn</span></span>
+  <span class="comment"># Attribute that defines the association</span>
   <span class="key">groupMembershipAttribute</span>: <span class="string"><span class="content">memberUid</span></span>
+  <span class="comment"># Filter groups by ObjectClass associated with group</span>
   <span class="key">groupClassName</span>: <span class="string"><span class="content">posixGroup</span></span>
-  <span class="comment"># Restrict groups to the following</span>
-  <span class="key">restrictToGroups</span>:
-    - <span class="string"><span class="content">user</span></span>
-    - <span class="string"><span class="content">admin</span></span>
-    - <span class="string"><span class="content">bots</span></span>
   <span class="key">connectTimeout</span>: <span class="string"><span class="content">500ms</span></span>
   <span class="key">readTimeout</span>: <span class="string"><span class="content">500ms</span></span></code></pre>
 </div>
@@ -591,7 +589,7 @@ in the launch config for end-to-end security</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-04-10 09:03:44 EDT
+Last updated 2015-04-14 15:44:51 EDT
 </div>
 </div>
 </body>

--- a/docs/html5/auth.html
+++ b/docs/html5/auth.html
@@ -553,7 +553,7 @@ over the admin port.</p>
 <div class="title">deploydb.launch.yml</div>
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="yaml"><span class="key">ldap</span>:
-  <span class="key">uri</span>: <span class="string"><span class="content">ldap://server.lookout.com:10389</span></span>
+  <span class="key">uri</span>: <span class="string"><span class="content">ldap://server.example.com:10389</span></span>
   <span class="comment"># Cache 10000 credentials for at least 10 minutes</span>
   <span class="key">cachePolicy</span>: <span class="string"><span class="content">maximumSize=10000, expireAfterWrite=10m</span></span>
   <span class="key">userFilter</span>: <span class="string"><span class="content">ou=people,dc=yourcompany,dc=com</span></span>
@@ -589,7 +589,7 @@ in the launch config for end-to-end security</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-04-14 15:44:51 EDT
+Last updated 2015-04-15 09:21:30 EDT
 </div>
 </div>
 </body>

--- a/features/api/deployment/reading.feature
+++ b/features/api/deployment/reading.feature
@@ -8,7 +8,7 @@ Feature: Deployment READ APIs
   Scenario: Fetching all deployments
 
     Given there is a deployment
-    When I GET "/api/deployments"
+    When I GET "/api/deployments" with "peter:griffin" as credentials
     Then the response should be 200
     And the body should be JSON:
     """
@@ -35,6 +35,13 @@ Feature: Deployment READ APIs
         "createdAt" : "{{created_timestamp}}"
       }]
     """
+
+  @error
+  Scenario: Fetching all deployments with invalid credentials fails with unauthorized code
+
+    Given there is a deployment
+    When I GET "/api/deployments" with "peter:familyguy" as credentials
+    Then the response should be 401
 
 
   @freezetime
@@ -115,7 +122,7 @@ Feature: Deployment READ APIs
   Scenario: Fetching an deployment by the pageNumber and perPageSize
 
     Given there are deployments
-    When I GET "/api/deployments?pageNumber=0&perPageSize=5"
+    When I GET "/api/deployments?pageNumber=0&perPageSize=5" with "peter:griffin" as credentials
     Then the response should be 200
     And the body should be JSON:
     """
@@ -169,14 +176,14 @@ Feature: Deployment READ APIs
   @error
   Scenario: Fetching an deployment with invalid page number
 
-    When I GET "/api/deployments?pageNumber=1&perPageSize=5"
+    When I GET "/api/deployments?pageNumber=1&perPageSize=5" with "peter:griffin" as credentials
     Then the response should be 404
 
 
   @error
   Scenario: Fetching an deployment with invalid data type for pageSize
 
-    When I GET "/api/deployments?pageNumber=-1&perPageSize=0xdeadbeef"
+    When I GET "/api/deployments?pageNumber=-1&perPageSize=0xdeadbeef" with "peter:griffin" as credentials
     Then the response should be 400
 
 
@@ -329,7 +336,7 @@ Feature: Deployment READ APIs
   Scenario: Fetching an deployment by pageNumber=0 and perPageSize=0 returns 0 deployments
 
     Given there are deployments
-    When I GET "/api/deployments?pageNumber=0&perPageSize=0"
+    When I GET "/api/deployments?pageNumber=0&perPageSize=0" with "peter:griffin" as credentials
     Then the response should be 400
 
 

--- a/features/api/deployment/reading.feature
+++ b/features/api/deployment/reading.feature
@@ -36,7 +36,7 @@ Feature: Deployment READ APIs
       }]
     """
 
-  @error
+  @error @wip
   Scenario: Fetching all deployments with invalid credentials fails with unauthorized code
 
     Given there is a deployment

--- a/src/asciidoc/auth.ad
+++ b/src/asciidoc/auth.ad
@@ -1,6 +1,6 @@
 = #DeployDB Authentication
 
-== Basic Authentication for Administrator
+== Basic HTTP Authentication for Administrator
 * Following configuration enables basic authentication for REST APIs available
   over the admin port.
 
@@ -12,29 +12,27 @@ http:
   adminPassword: password1234
 ----
 
-== LDAP Authentication
-* LDAP Authentication can be enabled on REST APIs using following
-  https://github.com/yammer/dropwizard-auth-ldap/blob/master/README.md#configuration[configuration]
-* The cache-policy should be configured to improve application's performance.
+== LDAP Authentication for Users
+* LDAP Authentication can be enabled on REST APIs using following configuration
+* The cache-policy should be configured to improve application's performance. More details can be found at
+  http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/cache/CacheBuilderSpec.html
+  [CacheBuilderSpec]
 
 [source,yaml]
 .deploydb.launch.yml
 ----
 ldap:
-  uri: ldaps://myldap.com:636
+  uri: ldap://server.lookout.com:10389
   # Cache 10000 credentials for at least 10 minutes
   cachePolicy: maximumSize=10000, expireAfterWrite=10m
   userFilter: ou=people,dc=yourcompany,dc=com
   groupFilter: ou=groups,dc=yourcompany,dc=com
   userNameAttribute: cn
   groupNameAttribute: cn
+  # Attribute that defines the association
   groupMembershipAttribute: memberUid
+  # Filter groups by ObjectClass associated with group
   groupClassName: posixGroup
-  # Restrict groups to the following
-  restrictToGroups:
-    - user
-    - admin
-    - bots
   connectTimeout: 500ms
   readTimeout: 500ms
 ----

--- a/src/asciidoc/auth.ad
+++ b/src/asciidoc/auth.ad
@@ -22,7 +22,7 @@ http:
 .deploydb.launch.yml
 ----
 ldap:
-  uri: ldap://server.lookout.com:10389
+  uri: ldap://server.example.com:10389
   # Cache 10000 credentials for at least 10 minutes
   cachePolicy: maximumSize=10000, expireAfterWrite=10m
   userFilter: ou=people,dc=yourcompany,dc=com

--- a/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/AppHelper.groovy
@@ -1,25 +1,24 @@
 package deploydb.cucumber
 
+import com.github.mustachejava.DefaultMustacheFactory
+import com.github.mustachejava.Mustache
 import deploydb.DeployDBApp
 import deploydb.ModelLoader
 import deploydb.models.Webhook.Webhook
-import webhookTestServer.webhookTestServerApp
-
-import com.github.mustachejava.DefaultMustacheFactory
-import com.github.mustachejava.Mustache
-
-import org.glassfish.jersey.client.ClientConfig
+import io.dropwizard.auth.basic.BasicCredentials
+import javax.ws.rs.core.Response
 import javax.ws.rs.client.Client
 import javax.ws.rs.client.ClientBuilder
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider
-import org.glassfish.jersey.client.JerseyInvocation
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
-import javax.ws.rs.core.Response
 import javax.ws.rs.client.Entity
-
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 import org.hibernate.context.internal.ManagedSessionContext
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider
+import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.client.JerseyInvocation
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
+import webhookTestServer.webhookTestServerApp
+
 
 class AppHelper {
     private StubAppRunner runner = null
@@ -122,10 +121,13 @@ class AppHelper {
         return writer.toString()
     }
 
-    Client getClient() {
+    Client getClient(BasicCredentials credentials) {
         if (this.jerseyClient == null) {
-            HttpAuthenticationFeature feature = HttpAuthenticationFeature.basicBuilder().build();
-            ClientConfig clientConfig = new ClientConfig(feature)
+            ClientConfig clientConfig = new ClientConfig()
+            /** Register HTTP Authentication feature, if credentials are provided */
+            if (credentials) {
+                clientConfig.register(HttpAuthenticationFeature.basicBuilder().build())
+            }
             clientConfig.connectorProvider(new ApacheConnectorProvider())
             this.jerseyClient = ClientBuilder.newClient(clientConfig)
         }
@@ -142,35 +144,63 @@ class AppHelper {
         return String.format("http://localhost:%d${path}", port)
     }
 
-
-    JerseyInvocation makeRequestToPath(String path, String method, Entity entity) {
-        return this.makeRequestToPath(path, method, entity, false)
+    /**
+     * Prepare a HTTP request
+     *
+     * @param path
+     * @param isAdmin
+     * @param credentials
+     * @return
+     */
+    JerseyInvocation.Builder makeRequestToPath(String path,
+                                               Boolean isAdmin,
+                                               BasicCredentials credentials) {
+        return getClient(credentials)
+                .target(urlWithPort(path, isAdmin))
+                .request()
     }
 
-    JerseyInvocation makeRequestToPath(String path, String method, Entity entity, Boolean isAdmin) {
-        return getClient().target(urlWithPort(path, isAdmin))
-                     .request()
-                     .build(method, entity)
-                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_USERNAME, "peter")
-                     .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_PASSWORD, "griffin")
+    /**
+     * Build the request with parameters
+     *
+     * @param builder
+     * @param method
+     * @param entity
+     * @param credentials
+     * @return
+     */
+    JerseyInvocation buildRequest(JerseyInvocation.Builder builder, String method,
+                                  Entity entity, BasicCredentials credentials) {
+        JerseyInvocation invocation = builder.build(method, entity)
+        if (credentials) {
+            invocation.property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_USERNAME,
+                    credentials.username)
+                    .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_PASSWORD,
+                    credentials.password)
+        }
+        return invocation
     }
 
     /**
      * Execute a POST to the test server for step definitions
      */
-    Response postJsonToPath(String path, String requestBody, Boolean isAdmin) {
-        return this.makeRequestToPath(path, 'POST', Entity.json(requestBody), isAdmin).invoke()
+    Response postJsonToPath(String path, String requestBody, Boolean isAdmin,
+                            BasicCredentials credentials) {
+        JerseyInvocation.Builder builder = this.makeRequestToPath(path, isAdmin, credentials)
+        return this.buildRequest(builder, 'POST', Entity.json(requestBody), credentials).invoke()
     }
 
     /**
      * Execute a PATCH to the test server for step definitions
      */
     Response patchJsonToPath(String path, String requestBody) {
-        return this.makeRequestToPath(path, 'PATCH', Entity.json(requestBody)).invoke()
+        JerseyInvocation.Builder builder = this.makeRequestToPath(path, false, null)
+        return this.buildRequest(builder, 'PATCH', Entity.json(requestBody), null).invoke()
     }
 
     Response deleteFromPath(String path) {
-        return this.makeRequestToPath(path, 'DELETE', null).invoke()
+        JerseyInvocation.Builder builder = this.makeRequestToPath(path, false, null)
+        return this.buildRequest(builder, 'DELETE', null, null).invoke()
     }
 
     /*
@@ -212,8 +242,9 @@ class AppHelper {
      * Minor convenience method to make sure we're dispatching GET requests to the
      * right port in our test application
      */
-    Response getFromPath(String path, boolean isAdmin) {
-        return this.makeRequestToPath(path, 'GET', null , isAdmin).invoke()
+    Response getFromPath(String path, boolean isAdmin, BasicCredentials credentials) {
+        JerseyInvocation.Builder builder = this.makeRequestToPath(path, isAdmin, credentials)
+        return this.buildRequest(builder, 'GET', null, credentials).invoke()
     }
 
     /** Set config directory */

--- a/src/cucumber/groovy/deploydb/cucumber/TestLdapServer.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/TestLdapServer.groovy
@@ -1,0 +1,89 @@
+package deploydb.cucumber
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig
+import com.unboundid.ldap.listener.InMemoryListenerConfig
+import com.unboundid.ldap.sdk.Attribute
+import com.unboundid.ldap.sdk.DN
+import com.unboundid.ldap.sdk.Entry
+import com.unboundid.ldap.sdk.LDAPException
+import com.unboundid.ldif.LDIFReader
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+final class TestLdapServer {
+
+    /**
+     * The in-memory instance of the UnboundID directory server.
+     */
+    private InMemoryDirectoryServer server = null
+
+    /**
+     * The root DN of the LDAP directory.
+     */
+    private String root = "dc=yourcompany,dc=com"
+    /**
+     * The distinguished name of the admin account.
+     */
+    private String authDn = "uid=admin,ou=system"
+    /**
+     * The password for the admin account.
+     */
+    private String passwd = "secret"
+    /**
+     * The LDIF file used to seed the LDAP directory.
+     */
+    private File ldifFile = new File("src/test/resources/testLdapServerConfig.ldif")
+    /**
+     * The TCP port on which the server is listening for LDAP traffic.
+     */
+    private int serverPort = 10389
+
+    private static final Logger logger = LoggerFactory.getLogger(TestLdapServer.class)
+
+    /**
+     * Configure and start the embedded UnboundID server creating the root DN and loading the LDIF seed data.
+     */
+    void start() {
+        try {
+            logger.info("Starting UnboundID server")
+            final InMemoryListenerConfig listenerConfig =
+                    InMemoryListenerConfig.createLDAPConfig("testLdapListener", serverPort)
+            final InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(new DN(root))
+            config.setListenerConfigs(listenerConfig)
+            config.setSchema(null)
+            if (authDn != null) {
+                config.addAdditionalBindCredentials(authDn, passwd)
+            }
+            server = new InMemoryDirectoryServer(config)
+            server.add(new Entry(root, new Attribute("objectclass", "domain", "top")))
+            if (ldifFile != null) {
+                final InputStream inputStream = new FileInputStream(ldifFile)
+                try {
+                    final LDIFReader reader = new LDIFReader(inputStream)
+                    server.importFromLDIF(false, reader)
+                } finally {
+                    inputStream.close()
+                }
+            }
+            server.startListening()
+            logger.info("Started UnboundID server")
+        } catch (final LDAPException e) {
+            e.printStackTrace()
+            logger.error("Could not launch embedded UnboundID directory server", e)
+        } catch (final IOException e) {
+            e.printStackTrace()
+            logger.error("Could not launch embedded UnboundID directory server", e)
+        }
+    }
+
+    /**
+     * Shutdown the the embedded UnboundID server.
+     */
+    void stop() {
+        logger.info("Stopping UnboundID server")
+        server.shutDown(true)
+        logger.info("Stopped UnboundID server")
+    }
+}

--- a/src/cucumber/groovy/step_definitions/DeploymentSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/DeploymentSteps.groovy
@@ -105,7 +105,7 @@ Given(~/^there are deployments for artifacts$/) { ->
 }
 
 When(~/I trigger deployment PATCH with:$/) { String path ->
-    response = postJsonToPath(path, requestBody, false)
+    response = postJsonToPath(path, requestBody, false, null)
 }
 
 And(~/there is a deployment in "(.*?)" state$/) { String deploymentState ->

--- a/src/cucumber/groovy/step_definitions/HttpSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/HttpSteps.groovy
@@ -3,8 +3,8 @@ import cucumber.api.DataTable
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import deploydb.WorkFlow
+import io.dropwizard.auth.basic.BasicCredentials
 import org.glassfish.jersey.client.JerseyInvocation
-import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
 import org.joda.time.DateTime
 
 // Add functions to register hooks and steps to this script.
@@ -12,11 +12,16 @@ this.metaClass.mixin(cucumber.api.groovy.Hooks)
 this.metaClass.mixin(cucumber.api.groovy.EN)
 
 When(~/^I GET "(.*?)" from the admin app$/) { String path ->
-    response = getFromPath(path, true)
+    response = getFromPath(path, true, null)
 }
 
 When(~/^I GET "(.*?)"$/) { String path ->
-    response = getFromPath(path, false)
+    response = getFromPath(path, false, null)
+}
+
+When(~/^I GET "(.*?)" with "(.*?):(.*?)" as credentials$/) {
+    String path, String username, String password ->
+        response = getFromPath(path, false, new BasicCredentials(username, password))
 }
 
 When(~/^I DELETE "(.*?)"$/) { String path ->
@@ -24,7 +29,12 @@ When(~/^I DELETE "(.*?)"$/) { String path ->
 }
 
 When(~/^I POST to "(.*?)" with:$/) { String path, String requestBody ->
-    response = postJsonToPath(path, requestBody, false)
+    response = postJsonToPath(path, requestBody, false, null)
+}
+
+When(~/^I POST to "(.*?)" with credentials "(.*?)","(.*?)" and:$/) {
+    String path, String username, String password, String requestBody ->
+    response = postJsonToPath(path, requestBody, false, new BasicCredentials(username, password))
 }
 
 When(~/^I POST to "(.*?)" with a (.*?) over ([1-9][0-9]*) characters$/) { String path, String var, int varSize ->
@@ -44,23 +54,23 @@ When(~/^I POST to "(.*?)" with a (.*?) over ([1-9][0-9]*) characters$/) { String
       }
     """
 
-    response = postJsonToPath(path, requestBody, false)
+    response = postJsonToPath(path, requestBody, false, null)
+}
+
+When(~/^I POST to "(.*?)"$/) { String path ->
+    response = postJsonToPath(path, null, false, null)
+}
+
+When(~/^I POST to "(.*?)" from the admin app$/) { String path ->
+    response = postJsonToPath(path, null, true, null)
 }
 
 When(~/^I PATCH "(.*?)" with:$/) { String path, String requestBody ->
     response = patchJsonToPath(path, requestBody)
 }
 
-When(~/^I POST to "(.*?)"$/) { String path ->
-    response = postJsonToPath(path, null, false)
-}
-
-When(~/^I POST to "(.*?)" from the admin app$/) { String path ->
-    response = postJsonToPath(path, null, true)
-}
-
 When(~/^I GET "(.*?)" with custom headers:$/) { String path, DataTable headers ->
-    JerseyInvocation.Builder builder = client.target(urlWithPort(path, false)).request()
+    JerseyInvocation.Builder builder = makeRequestToPath(path, false, null)
 
     List<List<String>> rawHeaders = headers.raw()
 
@@ -68,10 +78,7 @@ When(~/^I GET "(.*?)" with custom headers:$/) { String path, DataTable headers -
         builder.header(row[0] as String, row[1] as Object)
     }
 
-    response = builder.build('GET', null)
-            .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_USERNAME, "peter")
-            .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_PASSWORD, "griffin")
-            .invoke()
+    response = buildRequest(builder, 'GET', null, null).invoke()
 }
 
 

--- a/src/cucumber/groovy/step_definitions/HttpSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/HttpSteps.groovy
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import deploydb.WorkFlow
 import org.glassfish.jersey.client.JerseyInvocation
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature
 import org.joda.time.DateTime
 
 // Add functions to register hooks and steps to this script.
@@ -67,7 +68,10 @@ When(~/^I GET "(.*?)" with custom headers:$/) { String path, DataTable headers -
         builder.header(row[0] as String, row[1] as Object)
     }
 
-    response = builder.build('GET', null).invoke()
+    response = builder.build('GET', null)
+            .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_USERNAME, "peter")
+            .property(HttpAuthenticationFeature.HTTP_AUTHENTICATION_BASIC_PASSWORD, "griffin")
+            .invoke()
 }
 
 

--- a/src/cucumber/groovy/step_definitions/WebhookSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/WebhookSteps.groovy
@@ -114,7 +114,7 @@ When (~/^I POST to "(.*?)" with an artifact/) { String path ->
 "sourceUrl" : "http://example.com/maven/com.example.cucumber/cucumber-artifact/1.0.1/cucumber-artifact-1.0.1.jar"
 }"""
 
-    response = postJsonToPath(path, requestBody, false)
+    response = postJsonToPath(path, requestBody, false, null)
 }
 
 Then(~/^the webhook should be invoked with the JSON:$/) { String expectedMessageBody ->

--- a/src/main/groovy/deploydb/DeployDBApp.groovy
+++ b/src/main/groovy/deploydb/DeployDBApp.groovy
@@ -63,7 +63,7 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
             new HibernateBundle<DeployDBConfiguration>(models, new SessionFactoryFactory()) {
                 @Override
                 DataSourceFactory getDataSourceFactory(DeployDBConfiguration config) {
-                    return config.getDataSourceFactory()
+                    return config.database
                 }
             }
 
@@ -91,12 +91,12 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
         bootstrap.addBundle(new FlywayBundle<DeployDBConfiguration>() {
             @Override
             DataSourceFactory getDataSourceFactory(DeployDBConfiguration config) {
-                return config.getDataSourceFactory()
+                return config.database
             }
 
             @Override
             FlywayFactory getFlywayFactory(DeployDBConfiguration config) {
-                return config.getFlywayFactory()
+                return config.flyway
             }
         })
 
@@ -172,12 +172,11 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
         environment.admin().addTask(new ConfigReloadTask(workFlow))
 
         /** Register Ldap Authentication */
-        auth.LdapConfiguration ldapConfiguration = configuration.getLdapConfiguration()
-        if (ldapConfiguration.uri != null) {
+        if (configuration.ldapConfiguration.uri) {
             CachingAuthenticator<BasicCredentials, auth.User> authenticator = new CachingAuthenticator<>(
                     environment.metrics(),
-                    new auth.LdapAuthenticator(ldapConfiguration),
-                    ldapConfiguration.cachePolicy)
+                    new auth.LdapAuthenticator(configuration.ldapConfiguration),
+                    configuration.ldapConfiguration.cachePolicy)
             environment.jersey().register(
                     AuthFactory.binder(new BasicAuthFactory<auth.User>(authenticator,
                             "Please enter the user credentials",

--- a/src/main/groovy/deploydb/DeployDBApp.groovy
+++ b/src/main/groovy/deploydb/DeployDBApp.groovy
@@ -173,14 +173,16 @@ class DeployDBApp extends Application<DeployDBConfiguration> {
 
         /** Register Ldap Authentication */
         auth.LdapConfiguration ldapConfiguration = configuration.getLdapConfiguration()
-        CachingAuthenticator<BasicCredentials, auth.User> authenticator = new CachingAuthenticator<>(
-                environment.metrics(),
-                new auth.LdapAuthenticator(ldapConfiguration),
-                ldapConfiguration.cachePolicy)
-        environment.jersey().register(
-                AuthFactory.binder(new BasicAuthFactory<auth.User>(authenticator,
-                        "Please enter the user credentials",
-                        auth.User.class)))
+        if (ldapConfiguration.uri != null) {
+            CachingAuthenticator<BasicCredentials, auth.User> authenticator = new CachingAuthenticator<>(
+                    environment.metrics(),
+                    new auth.LdapAuthenticator(ldapConfiguration),
+                    ldapConfiguration.cachePolicy)
+            environment.jersey().register(
+                    AuthFactory.binder(new BasicAuthFactory<auth.User>(authenticator,
+                            "Please enter the user credentials",
+                            auth.User.class)))
+        }
 
         /**
          * Instantiate Resources classes for Jersey handlers

--- a/src/main/groovy/deploydb/DeployDBConfiguration.groovy
+++ b/src/main/groovy/deploydb/DeployDBConfiguration.groovy
@@ -13,76 +13,29 @@ import javax.validation.constraints.NotNull
 class DeployDBConfiguration extends Configuration {
     @Valid
     @NotNull
+    @JsonProperty("database")
     private DataSourceFactory database = new DataSourceFactory()
 
     @Valid
+    @JsonProperty("flyway")
     private FlywayFactory flyway = new FlywayFactory()
 
     @Valid
+    @JsonProperty("whoas")
     private WhoasFactory whoasFactory = new WhoasFactory()
 
     @Valid
     @NotNull
+    @JsonProperty
     private String configDirectory = ""
 
     @Valid
+    @NotNull
+    @JsonProperty("ldap")
     private auth.LdapConfiguration ldapConfiguration = new auth.LdapConfiguration()
 
+    @JsonProperty
     private ImmutableMap<String, ImmutableMap<String, String>> \
                             viewRendererConfiguration = ImmutableMap.of()
-
-    @JsonProperty("database")
-    DataSourceFactory getDataSourceFactory() {
-        return database
-    }
-
-    @JsonProperty("database")
-    void setDataSourceFactory(DataSourceFactory dataSourceFactory) {
-        this.database = dataSourceFactory;
-    }
-
-    @JsonProperty("flyway")
-    FlywayFactory getFlywayFactory() {
-        return flyway
-    }
-
-    @JsonProperty("flyway")
-    void setFlywayFactory(FlywayFactory flywayFactory) {
-        this.flyway = flywayFactory
-    }
-
-    @JsonProperty("configDirectory")
-    String getConfigDirectory() {
-        return configDirectory
-    }
-
-    @JsonProperty("configDirectory")
-    void setConfigDirectory(String configDirectory) {
-        this.configDirectory = configDirectory
-    }
-
-    @JsonProperty("whoas")
-    WhoasFactory getWhoasFactory() {
-        return whoasFactory
-    }
-
-    @JsonProperty("whoas")
-    void setWhoasFactory(WhoasFactory whoasFactory) {
-        this.whoasFactory = whoasFactory
-    }
-
-    @JsonProperty("ldap")
-    auth.LdapConfiguration getLdapConfiguration() {
-        return ldapConfiguration
-    }
-
-    @JsonProperty("ldap")
-    void setLdapConfiguration(auth.LdapConfiguration ldapConfiguration) {
-        this.ldapConfiguration = ldapConfiguration;
-    }
-
-    ImmutableMap<String, ImmutableMap<String, String>> getViewRendererConfiguration() {
-        return viewRendererConfiguration
-    }
 }
 

--- a/src/main/groovy/deploydb/DeployDBConfiguration.groovy
+++ b/src/main/groovy/deploydb/DeployDBConfiguration.groovy
@@ -1,14 +1,14 @@
 package deploydb
 
+import com.github.lookout.whoas.WhoasFactory
+import com.google.common.collect.ImmutableMap
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.dropwizard.Configuration
 import io.dropwizard.db.DataSourceFactory
 import io.dropwizard.flyway.FlywayFactory
-import com.github.lookout.whoas.WhoasFactory
-
-import com.google.common.collect.ImmutableMap
-import com.fasterxml.jackson.annotation.JsonProperty
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
+
 
 class DeployDBConfiguration extends Configuration {
     @Valid
@@ -24,6 +24,9 @@ class DeployDBConfiguration extends Configuration {
     @Valid
     @NotNull
     private String configDirectory = ""
+
+    @Valid
+    private auth.LdapConfiguration ldapConfiguration = new auth.LdapConfiguration()
 
     private ImmutableMap<String, ImmutableMap<String, String>> \
                             viewRendererConfiguration = ImmutableMap.of()
@@ -66,6 +69,16 @@ class DeployDBConfiguration extends Configuration {
     @JsonProperty("whoas")
     void setWhoasFactory(WhoasFactory whoasFactory) {
         this.whoasFactory = whoasFactory
+    }
+
+    @JsonProperty("ldap")
+    auth.LdapConfiguration getLdapConfiguration() {
+        return ldapConfiguration
+    }
+
+    @JsonProperty("ldap")
+    void setLdapConfiguration(auth.LdapConfiguration ldapConfiguration) {
+        this.ldapConfiguration = ldapConfiguration;
     }
 
     ImmutableMap<String, ImmutableMap<String, String>> getViewRendererConfiguration() {

--- a/src/main/groovy/deploydb/auth/LdapAuthenticator.groovy
+++ b/src/main/groovy/deploydb/auth/LdapAuthenticator.groovy
@@ -1,0 +1,135 @@
+package deploydb.auth
+
+import com.google.common.base.Optional
+import com.google.common.collect.ImmutableSet
+import io.dropwizard.auth.AuthenticationException
+import io.dropwizard.auth.Authenticator
+import io.dropwizard.auth.basic.BasicCredentials
+import javax.naming.AuthenticationException
+import javax.naming.Context
+import javax.naming.NamingEnumeration
+import javax.naming.NamingException
+import javax.naming.directory.InitialDirContext
+import javax.naming.directory.SearchControls
+import javax.naming.directory.SearchResult
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+
+class LdapAuthenticator implements Authenticator<BasicCredentials, BasicCredentials> {
+    private final LdapConfiguration configuration
+    private static final Logger logger = LoggerFactory.getLogger(LdapAuthenticator.class)
+
+    LdapAuthenticator(LdapConfiguration configuration) {
+        this.configuration = configuration
+    }
+
+    /* Take off everything but alphanumeric and some username specific chars */
+    private static String sanitizeEntity(String name) {
+        return name.replaceAll("[^A-Za-z0-9-_.]", "")
+    }
+
+    /**
+     * Creates, connects to LDAP server using JNDI
+     *
+     * @param sanitizedUsername
+     * @param password
+     * @return Directory context
+     * @throws NamingException
+     */
+    InitialDirContext buildContext(String sanitizedUsername, String password) throws NamingException {
+        final String userDN = String.format("%s=%s,%s", configuration.getUserNameAttribute(),
+                sanitizedUsername, configuration.getUserFilter())
+        final Hashtable<String, String> env = new Hashtable<>()
+
+        /** Common attributes */
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
+        env.put(Context.PROVIDER_URL, configuration.getUri().toString())
+        env.put("com.sun.jndi.ldap.connect.timeout",
+                String.valueOf(configuration.getConnectTimeout().toMilliseconds()))
+        env.put("com.sun.jndi.ldap.read.timeout",
+                String.valueOf(configuration.getReadTimeout().toMilliseconds()))
+        env.put("com.sun.jndi.ldap.connect.pool", "true")
+
+        /** User specific attributes */
+        env.put(Context.SECURITY_PRINCIPAL, userDN)
+        env.put(Context.SECURITY_CREDENTIALS, password)
+
+        return new InitialDirContext(env)
+    }
+
+    /**
+     * Search authorized groups for this user
+     *
+     * @param context
+     * @param userName
+     * @return Set of groupNames
+     */
+    private Set<String> getGroupMemberships(InitialDirContext context, String userName) {
+
+        /** Filter the user groups for configured groupClass (aka objectClass) */
+        final String filter = String.format("(&(%s=%s)(objectClass=%s))",
+                configuration.getGroupMembershipAttribute(), userName,
+                configuration.getGroupClassName(        ))
+
+        /** Limit the search results to groupNameAttribute only */
+        SearchControls searchCtls = new SearchControls();
+        def returnedAtts = [configuration.getGroupNameAttribute()] as String[]
+        searchCtls.setReturningAttributes(returnedAtts);
+
+        /** Search for group with filter & controls */
+        final NamingEnumeration<SearchResult> results = context.search(
+                configuration.getGroupFilter(), filter, searchCtls)
+
+        /** Walk and prepare the response */
+        ImmutableSet.Builder<String> overlappingGroups = ImmutableSet.builder()
+        try {
+            while (results.hasMore()) {
+                SearchResult current = results.next()
+                if (current.getAttributes() != null &&
+                        current.getAttributes().get(configuration.getGroupNameAttribute()) != null) {
+                    String group = (String) current.getAttributes().get(configuration.getGroupNameAttribute()).get(0)
+                    overlappingGroups.add(group)
+                }
+            }
+            return overlappingGroups.build()
+        } finally {
+            results.close()
+        }
+    }
+
+    /**
+     * Authenticate the user and return the groups associated with it.
+     *
+     * If there are no groups, user is still considered as authenticated, but with no groups.
+     *
+     * @param credentials
+     * @return User class
+     * @throws io.dropwizard.auth.AuthenticationException
+     */
+    @Override
+    Optional<User> authenticate(BasicCredentials credentials) throws AuthenticationException {
+        String pass = credentials.getPassword()
+
+        final String sanitizedUsername = sanitizeEntity(credentials.getUsername())
+        InitialDirContext context = null
+        try {
+            /** Authenticate */
+            context = buildContext(sanitizedUsername, credentials.getPassword())
+
+            /** Get a list of groups that this user is authorized for */
+            Set<String> groupMemberships = getGroupMemberships(context, sanitizedUsername)
+            return Optional.of(new User(sanitizedUsername, groupMemberships))
+        } catch (AuthenticationException ae) {
+            logger.error("${sanitizedUsername} failed to authenticate: ", ae)
+        } catch (NamingException err) {
+            throw new io.dropwizard.auth.AuthenticationException(
+                    "LDAP Authentication failure (username: ${sanitizedUsername})", err)
+        } finally {
+            if (context) {
+                context.close()
+            }
+        }
+        return Optional.absent()
+    }
+}

--- a/src/main/groovy/deploydb/auth/LdapAuthenticator.groovy
+++ b/src/main/groovy/deploydb/auth/LdapAuthenticator.groovy
@@ -1,130 +1,207 @@
 package deploydb.auth
 
 import com.google.common.base.Optional
-import com.google.common.collect.ImmutableSet
-import io.dropwizard.auth.AuthenticationException
+import groovy.transform.TypeChecked
 import io.dropwizard.auth.Authenticator
 import io.dropwizard.auth.basic.BasicCredentials
-import javax.naming.AuthenticationException
 import javax.naming.Context
 import javax.naming.NamingEnumeration
 import javax.naming.NamingException
 import javax.naming.directory.InitialDirContext
 import javax.naming.directory.SearchControls
 import javax.naming.directory.SearchResult
+import javax.validation.constraints.NotNull
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 
+@TypeChecked
 class LdapAuthenticator implements Authenticator<BasicCredentials, BasicCredentials> {
+    @NotNull
     private final LdapConfiguration configuration
     private static final Logger logger = LoggerFactory.getLogger(LdapAuthenticator.class)
 
+    /**
+     * The fully qualified class name of the factory class that will create
+     * an initial context.
+     */
+    static final String contextFactoryClassName = "com.sun.jndi.ldap.LdapCtxFactory"
+
+    /**
+     * The constant holds the name of property for specifying connect timeout
+     */
+    static final String connectTimeoutName = "com.sun.jndi.ldap.connect.timeout"
+
+    /**
+     * The constant holds the name of property for specifying read timeout
+     */
+    static final String readTimeoutName = "com.sun.jndi.ldap.read.timeout"
+
+    /**
+     * The constant holds the name of property for specifying connect pool
+     */
+    static final String connectPoolName = "com.sun.jndi.ldap.connect.pool"
+    static final String connectPoolTimeoutName = "com.sun.jndi.ldap.connect.pool.timeout"
+    static final String connectPoolTimeoutValue = "5000" /* in milliseconds */
+
+    /**
+     *  Constructor for LdapAuthenticator
+     *
+     * @param configuration - MUST be non null
+     */
     LdapAuthenticator(LdapConfiguration configuration) {
         this.configuration = configuration
-    }
-
-    /* Take off everything but alphanumeric and some username specific chars */
-    private static String sanitizeEntity(String name) {
-        return name.replaceAll("[^A-Za-z0-9-_.]", "")
     }
 
     /**
      * Creates, connects to LDAP server using JNDI
      *
-     * @param sanitizedUsername
-     * @param password
+     * @param credentials
      * @return Directory context
-     * @throws NamingException
+     * @throws NamingException if naming exception is encountered by underlying JNDI
+     * @throws ConnectException if uri is invalid
      */
-    InitialDirContext buildContext(String sanitizedUsername, String password) throws NamingException {
-        final String userDN = String.format("%s=%s,%s", configuration.getUserNameAttribute(),
-                sanitizedUsername, configuration.getUserFilter())
+    protected InitialDirContext buildContext(BasicCredentials credentials)
+            throws NamingException, ConnectException {
+
+        final String userDN = String.format("%s=%s,%s", configuration.userNameAttribute,
+                credentials.username, configuration.userFilter)
         final Hashtable<String, String> env = new Hashtable<>()
 
-        /** Common attributes */
-        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
-        env.put(Context.PROVIDER_URL, configuration.getUri().toString())
-        env.put("com.sun.jndi.ldap.connect.timeout",
-                String.valueOf(configuration.getConnectTimeout().toMilliseconds()))
-        env.put("com.sun.jndi.ldap.read.timeout",
-                String.valueOf(configuration.getReadTimeout().toMilliseconds()))
-        env.put("com.sun.jndi.ldap.connect.pool", "true")
+        /**
+         * Constant that holds the name of the environment property
+         * for specifying the initial context factory to use. The value
+         * of the property should be the fully qualified class name
+         * of the factory class that will create an initial context.
+         */
+        env.put(Context.INITIAL_CONTEXT_FACTORY, contextFactoryClassName)
+
+        /**
+         * URI of the LDAP server.
+         *
+         * In case of invalid URI or if connection fails to establish, then this
+         * function will throw a ConnectException.
+         */
+        env.put(Context.PROVIDER_URL, configuration.uri.toString())
+
+        /**
+         * If cannot establish a connection within a certain timeout period,
+         * it aborts the connection attempt.
+         *
+         * By default, this timeout period is the network (TCP) timeout value,
+         * which is in the order of a few minutes.
+         */
+        env.put(connectTimeoutName,
+                String.valueOf(configuration.connectTimeout.toMilliseconds()))
+
+        /**
+         * If the LDAP provider doesn't get an LDAP response within the specified
+         * readTimeout period, this setting aborts the read attempt.
+         *
+         * If this property is not specified, the default is to wait for the response
+         * until it is received.
+         */
+        env.put(readTimeoutName,
+                String.valueOf(configuration.readTimeout.toMilliseconds()))
+
+        /**
+         * Use connection pooling by using the environment property
+         */
+        env.put(connectPoolName, "true")
+
+        /**
+         * Set the pool timeout, so that the LDAP provider will automatically close and
+         * remove pooled connections that have been idle for more than the specified period.
+         */
+        env.put(connectPoolTimeoutName, connectPoolTimeoutValue)
 
         /** User specific attributes */
         env.put(Context.SECURITY_PRINCIPAL, userDN)
-        env.put(Context.SECURITY_CREDENTIALS, password)
+        env.put(Context.SECURITY_CREDENTIALS, credentials.password)
 
+        /** Create a context instance and initiate a connection to LDAP server */
         return new InitialDirContext(env)
     }
 
     /**
      * Search authorized groups for this user
      *
+     * The configuration attributes used in here are guaranteed to be non-null by annotation.
+     * If those parameters are mis-configured, then search query would fail
+     *
      * @param context
-     * @param userName
+     * @param username
      * @return Set of groupNames
      */
-    private Set<String> getGroupMemberships(InitialDirContext context, String userName) {
+    protected Set<String> getGroupMemberships(InitialDirContext context, String username)
+            throws NamingException {
 
-        /** Filter the user groups for configured groupClass (aka objectClass) */
+        /**
+         * Filter the user groups for configured groupClass (aka objectClass)
+         *
+         * Details about filter format can be found here:
+         * <http://docstore.mik.ua/orelly/java-ent/jenut/ch06_12.htm>
+         *
+         * E.g. (&(memberUid=myusername)(objectClass=groupOfUniqueNames))
+         * - Filter the groups where myusername is member AND objectClass is groupOfUniqueNames
+         */
         final String filter = String.format("(&(%s=%s)(objectClass=%s))",
-                configuration.getGroupMembershipAttribute(), userName,
-                configuration.getGroupClassName(        ))
+                configuration.groupMembershipAttribute, username,
+                configuration.groupClassName)
 
-        /** Limit the search results to groupNameAttribute only */
-        SearchControls searchCtls = new SearchControls();
-        def returnedAtts = [configuration.getGroupNameAttribute()] as String[]
-        searchCtls.setReturningAttributes(returnedAtts);
+        /**
+         * Optimize the output search results to single groupNameAttribute only
+         */
+        SearchControls searchCtls = new SearchControls()
+        String[] returnedAtts = [configuration.groupNameAttribute] as String[]
+        searchCtls.setReturningAttributes(returnedAtts)
 
-        /** Search for group with filter & controls */
+        /** Search for group with groupFilter string, filter & controls */
         final NamingEnumeration<SearchResult> results = context.search(
-                configuration.getGroupFilter(), filter, searchCtls)
+                configuration.groupFilter, filter, searchCtls)
 
         /** Walk and prepare the response */
-        ImmutableSet.Builder<String> overlappingGroups = ImmutableSet.builder()
+        Set<String> groups = new HashSet<>()
         try {
             while (results.hasMore()) {
                 SearchResult current = results.next()
                 if (current.getAttributes() != null &&
-                        current.getAttributes().get(configuration.getGroupNameAttribute()) != null) {
-                    String group = (String) current.getAttributes().get(configuration.getGroupNameAttribute()).get(0)
-                    overlappingGroups.add(group)
+                        current.getAttributes().get(configuration.groupNameAttribute) != null) {
+                    String group = (String) current.getAttributes().get(configuration.groupNameAttribute).get(0)
+                    groups.add(group)
                 }
             }
-            return overlappingGroups.build()
         } finally {
             results.close()
         }
+        return groups
     }
 
     /**
      * Authenticate the user and return the groups associated with it.
      *
-     * If there are no groups, user is still considered as authenticated, but with no groups.
+     * If there are no groups, user is still considered as authenticated,
+     * but is not associated with any groups.
+     *
+     * Logs all the authentication or naming exceptions and return authentication
+     * failure
      *
      * @param credentials
-     * @return User class
-     * @throws io.dropwizard.auth.AuthenticationException
+     * @return User - Optional User class
      */
     @Override
-    Optional<User> authenticate(BasicCredentials credentials) throws AuthenticationException {
-        String pass = credentials.getPassword()
-
-        final String sanitizedUsername = sanitizeEntity(credentials.getUsername())
+    Optional<User> authenticate(BasicCredentials credentials) {
         InitialDirContext context = null
         try {
             /** Authenticate */
-            context = buildContext(sanitizedUsername, credentials.getPassword())
+            context = buildContext(credentials)
 
             /** Get a list of groups that this user is authorized for */
-            Set<String> groupMemberships = getGroupMemberships(context, sanitizedUsername)
-            return Optional.of(new User(sanitizedUsername, groupMemberships))
-        } catch (AuthenticationException ae) {
-            logger.error("${sanitizedUsername} failed to authenticate: ", ae)
-        } catch (NamingException err) {
-            throw new io.dropwizard.auth.AuthenticationException(
-                    "LDAP Authentication failure (username: ${sanitizedUsername})", err)
+            Set<String> groupMemberships = getGroupMemberships(context, credentials.username)
+            return Optional.of(new User(credentials.username, groupMemberships))
+
+        } catch (Exception err) {
+            logger.error("${credentials.username} failed to authenticate with an Exception: ${err.getMessage()}")
         } finally {
             if (context) {
                 context.close()

--- a/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
+++ b/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
@@ -3,13 +3,12 @@ package deploydb.auth
 import com.google.common.cache.CacheBuilderSpec
 import io.dropwizard.util.Duration
 import javax.validation.Valid
-import javax.validation.constraints.NotNull
 
 
 class LdapConfiguration {
-    @NotNull
+
     @Valid
-    private URI uri = URI.create("ldap://hackers.lookout.com:636")
+    private URI uri = null
 
     @Valid
     private CacheBuilderSpec cachePolicy = CacheBuilderSpec.disableCaching()
@@ -26,8 +25,10 @@ class LdapConfiguration {
 
     private String groupClassName = "posixGroup"
 
+    @Valid
     private Duration connectTimeout = Duration.milliseconds(500)
 
+    @Valid
     private Duration readTimeout = Duration.milliseconds(500)
 
     URI getUri() {

--- a/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
+++ b/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
@@ -1,123 +1,81 @@
 package deploydb.auth
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.common.cache.CacheBuilderSpec
 import io.dropwizard.util.Duration
 import javax.validation.Valid
+import org.hibernate.validator.constraints.NotEmpty
 
 
+/**
+ * LdapConfiguration
+ *
+ * Contains LDAP specific configuration
+ *
+ * - All the attributes have defaults, hence none of these (except uri) can be null
+ * - @Valid on certain attributes ensures that contents are properly formatted
+ * - @NotEmpty ensures that user cannot skip configuring them
+ */
 class LdapConfiguration {
 
+    /**
+     * Uri to LDAP Server
+     *
+     * - Valid format: ldap://<hostname>:<optional port number>
+     * - "uri" can be null only if we are using default setting. In that case
+     *   no authentication is performed.
+     * - if "uri" is empty or invalid, then deploydb will attempt to connect and
+     *   authentication will fail
+     */
     @Valid
+    @JsonProperty
     private URI uri = null
 
-    @Valid
+    /** Cache policy cannot be null, but it can be empty i.e. no caching */
+    @JsonProperty
     private CacheBuilderSpec cachePolicy = CacheBuilderSpec.disableCaching()
 
+    @NotEmpty
+    @JsonProperty
     private String userFilter = "ou=people,dc=example,dc=com"
 
+    @NotEmpty
+    @JsonProperty
     private String groupFilter = "ou=groups,dc=example,dc=com"
 
+    @NotEmpty
+    @JsonProperty
     private String userNameAttribute = "cn"
 
+    @NotEmpty
+    @JsonProperty
     private String groupNameAttribute = "cn"
 
+    @NotEmpty
+    @JsonProperty
     private String groupMembershipAttribute = "memberUid"
 
+    @NotEmpty
+    @JsonProperty
     private String groupClassName = "posixGroup"
 
     @Valid
+    @JsonProperty
     private Duration connectTimeout = Duration.milliseconds(500)
 
     @Valid
+    @JsonProperty
     private Duration readTimeout = Duration.milliseconds(500)
 
-    URI getUri() {
-        return uri
-    }
-
-    LdapConfiguration setUri(URI uri) {
-        this.uri = uri
-        return this
-    }
-
-    CacheBuilderSpec getCachePolicy() {
-        return cachePolicy
-    }
-
-    LdapConfiguration setCachePolicy(CacheBuilderSpec cachePolicy) {
-        this.cachePolicy = cachePolicy
-        return this
-    }
-
-    String getUserFilter() {
-        return userFilter
-    }
-
-    LdapConfiguration setUserFilter(String userFilter) {
-        this.userFilter = userFilter
-        return this
-    }
-
-    String getGroupFilter() {
-        return groupFilter
-    }
-
-    LdapConfiguration setGroupFilter(String groupFilter) {
-        this.groupFilter = groupFilter
-        return this
-    }
-
-    String getUserNameAttribute() {
-        return userNameAttribute
-    }
-
-    LdapConfiguration setUserNameAttribute(String userNameAttribute) {
-        this.userNameAttribute = userNameAttribute
-        return this
-    }
-
-    String getGroupNameAttribute() {
-        return groupNameAttribute
-    }
-
-    LdapConfiguration setGroupNameAttribute(String groupNameAttribute) {
-        this.groupNameAttribute = groupNameAttribute
-        return this
-    }
-
-    String getGroupMembershipAttribute() {
-        return groupMembershipAttribute
-    }
-
-    LdapConfiguration setGroupMembershipAttribute(String groupMembershipAttribute) {
-        this.groupMembershipAttribute = groupMembershipAttribute
-        return this
-    }
-
-    String getGroupClassName() {
-        return groupClassName
-    }
-
-    LdapConfiguration setGroupClassName(String groupClassName) {
-        this.groupClassName = groupClassName
-        return this
-    }
-
-    Duration getConnectTimeout() {
-        return connectTimeout
-    }
-
-    LdapConfiguration setConnectTimeout(Duration connectTimeout) {
-        this.connectTimeout = connectTimeout
-        return this
-    }
-
-    Duration getReadTimeout() {
-        return readTimeout
-    }
-
-    LdapConfiguration setReadTimeout(Duration readTimeout) {
-        this.readTimeout = readTimeout
-        return this
+    /** Validate uri */
+    boolean isValidLdapUri() {
+        println "uri = ${uri.toString()}"
+        try {
+            URI u = URI.create(uri.toString());
+            return "ldap".equals(u.getScheme())
+        } catch (Exception ex) {
+            println "$uri - validation failed: " + ex.getMessage()
+        }
+        return false
     }
 }

--- a/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
+++ b/src/main/groovy/deploydb/auth/LdapConfiguration.groovy
@@ -1,0 +1,122 @@
+package deploydb.auth
+
+import com.google.common.cache.CacheBuilderSpec
+import io.dropwizard.util.Duration
+import javax.validation.Valid
+import javax.validation.constraints.NotNull
+
+
+class LdapConfiguration {
+    @NotNull
+    @Valid
+    private URI uri = URI.create("ldap://hackers.lookout.com:636")
+
+    @Valid
+    private CacheBuilderSpec cachePolicy = CacheBuilderSpec.disableCaching()
+
+    private String userFilter = "ou=people,dc=example,dc=com"
+
+    private String groupFilter = "ou=groups,dc=example,dc=com"
+
+    private String userNameAttribute = "cn"
+
+    private String groupNameAttribute = "cn"
+
+    private String groupMembershipAttribute = "memberUid"
+
+    private String groupClassName = "posixGroup"
+
+    private Duration connectTimeout = Duration.milliseconds(500)
+
+    private Duration readTimeout = Duration.milliseconds(500)
+
+    URI getUri() {
+        return uri
+    }
+
+    LdapConfiguration setUri(URI uri) {
+        this.uri = uri
+        return this
+    }
+
+    CacheBuilderSpec getCachePolicy() {
+        return cachePolicy
+    }
+
+    LdapConfiguration setCachePolicy(CacheBuilderSpec cachePolicy) {
+        this.cachePolicy = cachePolicy
+        return this
+    }
+
+    String getUserFilter() {
+        return userFilter
+    }
+
+    LdapConfiguration setUserFilter(String userFilter) {
+        this.userFilter = userFilter
+        return this
+    }
+
+    String getGroupFilter() {
+        return groupFilter
+    }
+
+    LdapConfiguration setGroupFilter(String groupFilter) {
+        this.groupFilter = groupFilter
+        return this
+    }
+
+    String getUserNameAttribute() {
+        return userNameAttribute
+    }
+
+    LdapConfiguration setUserNameAttribute(String userNameAttribute) {
+        this.userNameAttribute = userNameAttribute
+        return this
+    }
+
+    String getGroupNameAttribute() {
+        return groupNameAttribute
+    }
+
+    LdapConfiguration setGroupNameAttribute(String groupNameAttribute) {
+        this.groupNameAttribute = groupNameAttribute
+        return this
+    }
+
+    String getGroupMembershipAttribute() {
+        return groupMembershipAttribute
+    }
+
+    LdapConfiguration setGroupMembershipAttribute(String groupMembershipAttribute) {
+        this.groupMembershipAttribute = groupMembershipAttribute
+        return this
+    }
+
+    String getGroupClassName() {
+        return groupClassName
+    }
+
+    LdapConfiguration setGroupClassName(String groupClassName) {
+        this.groupClassName = groupClassName
+        return this
+    }
+
+    Duration getConnectTimeout() {
+        return connectTimeout
+    }
+
+    LdapConfiguration setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout
+        return this
+    }
+
+    Duration getReadTimeout() {
+        return readTimeout
+    }
+
+    LdapConfiguration setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout
+        return this
+    }
+}

--- a/src/main/groovy/deploydb/auth/User.groovy
+++ b/src/main/groovy/deploydb/auth/User.groovy
@@ -1,0 +1,14 @@
+package deploydb.auth
+
+/**
+ * User class
+ */
+class User {
+    private final String name
+    private final Set<String> groups
+
+    User(String name, Set<String> groups) {
+        this.name = name
+        this.groups = groups
+    }
+}

--- a/src/main/groovy/deploydb/auth/User.groovy
+++ b/src/main/groovy/deploydb/auth/User.groovy
@@ -2,9 +2,15 @@ package deploydb.auth
 
 /**
  * User class
+ *
+ * Once the user is authenticated, this object contains information
+ * that user is authorized for
  */
 class User {
+    /** Username */
     private final String name
+
+    /** Groups that user is authorized to be part of */
     private final Set<String> groups
 
     User(String name, Set<String> groups) {

--- a/src/main/groovy/deploydb/resources/DeploymentResource.groovy
+++ b/src/main/groovy/deploydb/resources/DeploymentResource.groovy
@@ -1,20 +1,18 @@
 package deploydb.resources
 
 import com.codahale.metrics.annotation.Timed
-
 import deploydb.Status
 import deploydb.WorkFlow
+import deploydb.auth.User
 import deploydb.mappers.PromotionResultAddMapper
 import deploydb.models.Deployment
 import deploydb.models.PromotionResult
 import deploydb.mappers.DeploymentUpdateMapper
-
+import io.dropwizard.auth.Auth
 import io.dropwizard.jersey.params.IntParam
 import io.dropwizard.jersey.params.LongParam
 import io.dropwizard.jersey.PATCH
 import io.dropwizard.hibernate.UnitOfWork
-import org.apache.commons.lang3.tuple.Pair
-
 import javax.servlet.http.HttpServletRequest
 import javax.validation.Valid
 import javax.ws.rs.Consumes
@@ -29,6 +27,7 @@ import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Context
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
+import org.apache.commons.lang3.tuple.Pair
 
 
 @Path("/api/deployments")
@@ -47,11 +46,10 @@ public class DeploymentResource {
     @GET
     @UnitOfWork
     @Timed(name = "get-requests")
-    List<Deployment> getAll(
+    List<Deployment> getAll(@Auth User user,
             @QueryParam("pageNumber") @DefaultValue("0") IntParam pageNumber,
             @QueryParam("perPageSize") @DefaultValue("20") deploydb.ModelPageSizeParam
                     perPageSize) {
-
         /**
          * Fetch deployment by page
          */

--- a/src/test/groovy/deploydb/auth/LdapAuthenticatorSpec.groovy
+++ b/src/test/groovy/deploydb/auth/LdapAuthenticatorSpec.groovy
@@ -1,16 +1,13 @@
-package deploydb
+package deploydb.auth
 
 import com.google.common.base.Optional
 import io.dropwizard.auth.basic.BasicCredentials
-import javax.naming.AuthenticationException
-import javax.naming.Context
 import javax.naming.NamingEnumeration
 import javax.naming.NamingException
 import javax.naming.directory.InitialDirContext
 import javax.naming.directory.Attributes
 import javax.naming.directory.BasicAttribute
 import javax.naming.directory.BasicAttributes
-import javax.naming.directory.SearchControls
 import javax.naming.directory.SearchResult
 import spock.lang.*
 
@@ -20,15 +17,16 @@ class LdapAuthenticatorSpec extends Specification {
 
     def "ensure it can be instantiated"() {
         when:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        def ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def ldapConfiguration = new LdapConfiguration()
+        def ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
 
         then:
-        ldapAuthenticator instanceof auth.LdapAuthenticator
+        ldapAuthenticator instanceof LdapAuthenticator
     }
 }
 
 class LdapAuthenticatorWithArgsSpec extends Specification {
+    LdapConfiguration ldapConfiguration
 
     class TestNamingEnumeration<SearchResult> extends NamingEnumeration {
         @Override
@@ -43,35 +41,27 @@ class LdapAuthenticatorWithArgsSpec extends Specification {
         SearchResult nextElement() { throw new NoSuchElementException() }
     }
 
-    def "Successful authentication and getGroupMembership"() {
+    def setup() {
+        ldapConfiguration = new LdapConfiguration()
+    }
+
+    def "authenticate() - successful authentication"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
-        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
-
-        /* Cookup SearchResult */
-        Attributes matchAttrs = new BasicAttributes(true);
-        matchAttrs.put(new BasicAttribute("cn", "Fandango"));
-        def result = new SearchResult("fauxname", null, matchAttrs)
-
-        /* Context calls mocking */
-        1 * context.search(_, _, _) >> results
+        /** Define interface objects */
+        Set<String> groups = ["Fandango"]
+        InitialDirContext context = Mock(InitialDirContext)
         1 * context.close() >> _
-        0 * context._
 
-        /* buildContext partial mocking */
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
-
-        /* Naming Enumeration Mocking */
-        1 * results.hasMore() >> true
-        1 * results.hasMore() >> false
-        1 * results.close()
-        1 * results.next() >> result
-        0 * results._
+        /** Create LdapAuthenticator */
+        LdapAuthenticator ldapAuthenticator =
+                Spy(LdapAuthenticator, constructorArgs: [ldapConfiguration]) {
+                    /** Mock interface functions */
+                    buildContext(_) >> context
+                    getGroupMemberships(_, _) >> groups
+                }
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Optional<User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
 
         then:
         userOpt.isPresent() == true
@@ -80,153 +70,240 @@ class LdapAuthenticatorWithArgsSpec extends Specification {
         userOpt.get().groups[0] == "Fandango"
     }
 
-    def "Unsuccessful authentication case, logs the exception"() {
+    def "authenticate() - when buildContext throws NamingException, then should return failure"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-
-        /* buildContext partial mocking */
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass ->
-            throw new AuthenticationException()
-        }
+        LdapAuthenticator ldapAuthenticator =
+                Spy(LdapAuthenticator, constructorArgs: [ldapConfiguration]) {
+                    /** Mock interface functions */
+                    buildContext(_, _) >> { throw new NamingException("test") }
+                }
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Optional<User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
 
         then:
         userOpt.isPresent() == false
     }
 
-    def "getGroupMembership fails in attribute match, groups SET is empty"() {
+    def "authenticate() - when buildContext throws ConnectException, then should return failure"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
-        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
-
-        /* Cookup SearchResult */
-        Attributes matchAttrs = new BasicAttributes(true);
-        matchAttrs.put(new BasicAttribute("app", "Fandango")); /* Does not match groupNameAtribute */
-        def result = new SearchResult("fauxname", null, matchAttrs)
-
-        /* Context calls mocking */
-        1 * context.search(_, _, _) >> results
-        1 * context.close() >> _
-        0 * context._
-
-        /* buildContext partial mocking */
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
-
-        /* Naming Enumeration Mocking */
-        1 * results.hasMore() >> true
-        1 * results.hasMore() >> false
-        1 * results.close()
-        1 * results.next() >> result
-        0 * results._
+        LdapAuthenticator ldapAuthenticator =
+                Spy(LdapAuthenticator, constructorArgs: [ldapConfiguration]) {
+                    /** Mock interface functions */
+                    buildContext(_, _) >> { throw new ConnectException("test") }
+                }
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Optional<User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
 
         then:
-        userOpt.isPresent() == true
-        userOpt.get().name == "foo"
-        userOpt.get().groups.isEmpty() == true
+        userOpt.isPresent() == false
     }
 
-    def "getGroupMembership returns empty SearchResult, groups SET is empty"() {
+    def "authenticate() - when getGroupMemberShips throws an exception"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
-
-        /* Context call mocking */
-        1 * context.search(_, _, _) >> new TestNamingEnumeration()
+        /** Define interface objects */
+        InitialDirContext context = Mock(InitialDirContext)
         1 * context.close() >> _
-        0 * context._
 
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+        /** Create LdapAuthenticator */
+        LdapAuthenticator ldapAuthenticator =
+                Spy(LdapAuthenticator, constructorArgs: [ldapConfiguration]) {
+                    /** Mock interface functions */
+                    buildContext(_) >> context
+                    getGroupMemberships(_, _) >> { throw new NamingException("test") }
+                }
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Optional<User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
 
         then:
-        userOpt.isPresent() == true
-        userOpt.get().name == "foo"
-        userOpt.get().groups.isEmpty() == true
+        userOpt.isPresent() == false
     }
 
-    def "getGroupMembership returns empty SearchResult, groups SET is empty"() {
+    @Ignore
+    def "buildContext() - successful authentication"() {
+        //TO DO - when LDAP server is available with SPOCK tests
+        //when:
+        // launch ldap server
+        // create dir context and make sure it returns a valid context
+        //then:
+        //success
+    }
+
+    @Ignore
+    def "buildContext() - ldap server returns authentication failure"() {
+        //TO DO - when LDAP server is available with SPOCK tests
+        //when:
+        // launch ldap server
+        // create dir context and make sure it returns a valid context
+        //then:
+        // Authentication exception
+    }
+
+    def "buildContext() - empty uri causes ConfigurationException to be thrown"() {
+        when:
+        ldapConfiguration.uri = new URI("")
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
+        InitialDirContext context = ldapAuthenticator.buildContext(new BasicCredentials("foo", "bar"))
+
+        then:
+        thrown(javax.naming.ConfigurationException)
+    }
+
+    def "buildContext() - uri with non-ldap protocol causes NamingException to be thrown"() {
+        when:
+        ldapConfiguration.uri = new URI("http://localhost:10389")
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
+        InitialDirContext context = ldapAuthenticator.buildContext(new BasicCredentials("foo", "bar"))
+
+        then:
+        thrown(javax.naming.NamingException)
+    }
+
+    def "buildContext() - malformed uri causes NamingException to be thrown"() {
+        when:
+        ldapConfiguration.uri = new URI("ldap:localhost:10389")
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
+        InitialDirContext context = ldapAuthenticator.buildContext(new BasicCredentials("foo", "bar"))
+
+        then:
+        thrown(javax.naming.NamingException)
+    }
+
+    def "getGroupMemberships() - successful to retrieve groups"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
+        ldapConfiguration.groupNameAttribute = "pizza"
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
 
-        /* Context call mocking */
-        1 * context.search(_, _, _) >> new TestNamingEnumeration()
-        1 * context.close() >> _
-        0 * context._
-
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+        /**
+         * Mock the interfaces to return following attributes
+         */
+        InitialDirContext context = mockGetGroupMembershipInterface("pizza", "Fandango")
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Set<String> groups = ldapAuthenticator.getGroupMemberships(context, "foo")
 
         then:
-        userOpt.isPresent() == true
-        userOpt.get().name == "foo"
-        userOpt.get().groups.isEmpty() == true
+        groups.size() == 1
+        groups[0] == "Fandango"
     }
 
-    def "context.search() throws NamingException, in turn authenticate raise AuthenticationException"() {
+    def "getGroupMemberships() - returns empty SET on groupNameAttribute mismatch"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
+        ldapConfiguration.groupNameAttribute = "pizza"
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
 
-        /* Context calls mocking */
+        /**
+         * Mock the interfaces to return following attributes
+         */
+        InitialDirContext context = mockGetGroupMembershipInterface("BadPizza", "Fandango")
+
+        when:
+        Set<String> groups = ldapAuthenticator.getGroupMemberships(context, "foo")
+
+        then:
+        groups.size() == 0
+    }
+
+    @Ignore
+    def "getGroupMemberships() - returns empty SET on groupClassName fails to match"() {
+        //TO DO - when LDAP server is available with SPOCK tests
+    }
+
+    def "getGroupMembership() - returns empty SET when context.search() returns are empty"() {
+        given:
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
+
+        /**
+         * Mock the InitialDirContext to return empty NamingEnumeration
+         */
+        TestNamingEnumeration<SearchResult> emptyResults = new TestNamingEnumeration<SearchResult>()
+        InitialDirContext context = mockInitialDirContext() { return emptyResults }
+
+        when:
+        Set<String> groups = ldapAuthenticator.getGroupMemberships(context, "foo")
+
+        then:
+        groups.size() == 0
+    }
+
+    def "getGroupMembership() - rethrows the NamingException raised by context.search()"() {
+        given:
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
+
+        /** Mock InitialDirContext with context.search to throw an exception */
+        InitialDirContext context = Mock(InitialDirContext)
         1 * context.search(_, _, _) >> { throw new NamingException() }
-        1 * context.close() >> _
         0 * context._
-
-        /* buildContext partial mocking */
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
 
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Set<String> groups = ldapAuthenticator.getGroupMemberships(context, "foo")
 
         then:
-        thrown(io.dropwizard.auth.AuthenticationException)
+        thrown(NamingException)
     }
 
-    def "results.hasMore() throws NamingException, in turn authenticate raise AuthenticationException"() {
+    def "getGroupMembership() - rethrows the NamingException raised by results.hasMore()"() {
         given:
-        def ldapConfiguration = new auth.LdapConfiguration()
-        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
-        def context = Mock(InitialDirContext)
-        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
-
-        /* Cookup SearchResult */
-        Attributes matchAttrs = new BasicAttributes(true);
-        matchAttrs.put(new BasicAttribute("cn", "Fandango"));
-        def result = new SearchResult("fauxname", null, matchAttrs)
-
-        /* Context calls mocking */
-        1 * context.search(_, _, _) >> results
-        1 * context.close() >> _
-        0 * context._
-
-        /* buildContext partial mocking */
-        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(ldapConfiguration)
 
         /* Naming Enumeration Mocking */
+        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
         1 * results.hasMore() >> { throw new NamingException() }
         1 * results.close()
         0 * results._
 
+        /** Mock InitialDirContext to return "results"*/
+        InitialDirContext context = mockInitialDirContext() { return results }
+
         when:
-        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+        Set<String> groups = ldapAuthenticator.getGroupMemberships(context, "foo")
 
         then:
-        thrown(io.dropwizard.auth.AuthenticationException)
+        thrown(NamingException)
+    }
+
+    /* Class Helpers */
+
+    /** Mock InitialDirContext */
+    InitialDirContext mockInitialDirContext(Closure closure) {
+        InitialDirContext context = Mock(InitialDirContext)
+        1 * context.search(_, _, _) >> closure.call()
+        0 * context._
+        return context
+    }
+
+    /* Populate SearchResult */
+    SearchResult populateSearchResult(String attribType, String attribValue) {
+        Attributes matchAttrs = new BasicAttributes(true);
+        matchAttrs.put(new BasicAttribute(attribType, attribValue));
+        return new SearchResult("faux_name", null, matchAttrs)
+    }
+
+    /** Mock TestNamingEnumeration for 1 walk through the while loop */
+    TestNamingEnumeration<SearchResult> mockResultsWalkOneLoop(Closure closure) {
+        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
+        1 * results.hasMore() >> true
+        1 * results.hasMore() >> false
+        1 * results.close()
+        1 * results.next() >> closure.call()
+        0 * results._
+
+        return results
+    }
+
+    /** Mocking all interfaces of getGroupMemberships() */
+    InitialDirContext mockGetGroupMembershipInterface(String attribType, String attribValue) {
+        /** Populate SearchResult */
+        SearchResult result = populateSearchResult(attribType, attribValue)
+
+        /** Mock NamingEnumeration to walk through while loop once and return "result" */
+        TestNamingEnumeration<SearchResult> results = mockResultsWalkOneLoop() { return result }
+
+        /** Mock InitialDirContext to return "results"*/
+        InitialDirContext context = mockInitialDirContext() { return results }
+
+        return context
     }
 }

--- a/src/test/groovy/deploydb/auth/LdapAuthenticatorSpec.groovy
+++ b/src/test/groovy/deploydb/auth/LdapAuthenticatorSpec.groovy
@@ -1,0 +1,232 @@
+package deploydb
+
+import com.google.common.base.Optional
+import io.dropwizard.auth.basic.BasicCredentials
+import javax.naming.AuthenticationException
+import javax.naming.Context
+import javax.naming.NamingEnumeration
+import javax.naming.NamingException
+import javax.naming.directory.InitialDirContext
+import javax.naming.directory.Attributes
+import javax.naming.directory.BasicAttribute
+import javax.naming.directory.BasicAttributes
+import javax.naming.directory.SearchControls
+import javax.naming.directory.SearchResult
+import spock.lang.*
+
+import javax.validation.OverridesAttribute
+
+class LdapAuthenticatorSpec extends Specification {
+
+    def "ensure it can be instantiated"() {
+        when:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        def ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+
+        then:
+        ldapAuthenticator instanceof auth.LdapAuthenticator
+    }
+}
+
+class LdapAuthenticatorWithArgsSpec extends Specification {
+
+    class TestNamingEnumeration<SearchResult> extends NamingEnumeration {
+        @Override
+        SearchResult next() throws NamingException { return null }
+        @Override
+        boolean hasMore() throws NamingException { return false }
+        @Override
+        void close() throws NamingException { }
+        @Override
+        boolean hasMoreElements() { return false }
+        @Override
+        SearchResult nextElement() { throw new NoSuchElementException() }
+    }
+
+    def "Successful authentication and getGroupMembership"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
+
+        /* Cookup SearchResult */
+        Attributes matchAttrs = new BasicAttributes(true);
+        matchAttrs.put(new BasicAttribute("cn", "Fandango"));
+        def result = new SearchResult("fauxname", null, matchAttrs)
+
+        /* Context calls mocking */
+        1 * context.search(_, _, _) >> results
+        1 * context.close() >> _
+        0 * context._
+
+        /* buildContext partial mocking */
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        /* Naming Enumeration Mocking */
+        1 * results.hasMore() >> true
+        1 * results.hasMore() >> false
+        1 * results.close()
+        1 * results.next() >> result
+        0 * results._
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        userOpt.isPresent() == true
+        userOpt.get().name == "foo"
+        userOpt.get().groups.size() == 1
+        userOpt.get().groups[0] == "Fandango"
+    }
+
+    def "Unsuccessful authentication case, logs the exception"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+
+        /* buildContext partial mocking */
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass ->
+            throw new AuthenticationException()
+        }
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        userOpt.isPresent() == false
+    }
+
+    def "getGroupMembership fails in attribute match, groups SET is empty"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
+
+        /* Cookup SearchResult */
+        Attributes matchAttrs = new BasicAttributes(true);
+        matchAttrs.put(new BasicAttribute("app", "Fandango")); /* Does not match groupNameAtribute */
+        def result = new SearchResult("fauxname", null, matchAttrs)
+
+        /* Context calls mocking */
+        1 * context.search(_, _, _) >> results
+        1 * context.close() >> _
+        0 * context._
+
+        /* buildContext partial mocking */
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        /* Naming Enumeration Mocking */
+        1 * results.hasMore() >> true
+        1 * results.hasMore() >> false
+        1 * results.close()
+        1 * results.next() >> result
+        0 * results._
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        userOpt.isPresent() == true
+        userOpt.get().name == "foo"
+        userOpt.get().groups.isEmpty() == true
+    }
+
+    def "getGroupMembership returns empty SearchResult, groups SET is empty"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+
+        /* Context call mocking */
+        1 * context.search(_, _, _) >> new TestNamingEnumeration()
+        1 * context.close() >> _
+        0 * context._
+
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        userOpt.isPresent() == true
+        userOpt.get().name == "foo"
+        userOpt.get().groups.isEmpty() == true
+    }
+
+    def "getGroupMembership returns empty SearchResult, groups SET is empty"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+
+        /* Context call mocking */
+        1 * context.search(_, _, _) >> new TestNamingEnumeration()
+        1 * context.close() >> _
+        0 * context._
+
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        userOpt.isPresent() == true
+        userOpt.get().name == "foo"
+        userOpt.get().groups.isEmpty() == true
+    }
+
+    def "context.search() throws NamingException, in turn authenticate raise AuthenticationException"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+
+        /* Context calls mocking */
+        1 * context.search(_, _, _) >> { throw new NamingException() }
+        1 * context.close() >> _
+        0 * context._
+
+        /* buildContext partial mocking */
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        thrown(io.dropwizard.auth.AuthenticationException)
+    }
+
+    def "results.hasMore() throws NamingException, in turn authenticate raise AuthenticationException"() {
+        given:
+        def ldapConfiguration = new auth.LdapConfiguration()
+        auth.LdapAuthenticator ldapAuthenticator = new auth.LdapAuthenticator(ldapConfiguration)
+        def context = Mock(InitialDirContext)
+        TestNamingEnumeration<SearchResult> results = Mock(TestNamingEnumeration)
+
+        /* Cookup SearchResult */
+        Attributes matchAttrs = new BasicAttributes(true);
+        matchAttrs.put(new BasicAttribute("cn", "Fandango"));
+        def result = new SearchResult("fauxname", null, matchAttrs)
+
+        /* Context calls mocking */
+        1 * context.search(_, _, _) >> results
+        1 * context.close() >> _
+        0 * context._
+
+        /* buildContext partial mocking */
+        ldapAuthenticator.metaClass.buildContext = { String username, String pass -> return context }
+
+        /* Naming Enumeration Mocking */
+        1 * results.hasMore() >> { throw new NamingException() }
+        1 * results.close()
+        0 * results._
+
+        when:
+        Optional<auth.User> userOpt = ldapAuthenticator.authenticate(new BasicCredentials("foo", "bar"))
+
+        then:
+        thrown(io.dropwizard.auth.AuthenticationException)
+    }
+}

--- a/src/test/resources/testLdapServerConfig.ldif
+++ b/src/test/resources/testLdapServerConfig.ldif
@@ -1,0 +1,57 @@
+dn: ou=people,dc=yourcompany,dc=com
+ou: people
+objectClass: organizationalUnit
+
+dn: ou=groups,dc=yourcompany,dc=com
+ou: groups
+objectClass: organizationalUnit
+
+dn: cn=fox,ou=groups,dc=yourcompany,dc=com
+cn: fox
+add: memberUid
+memberUid: bart
+memberUid: lisa
+memberUid: peter
+memberUid: lois
+objectClass: groupOfUniqueNames
+
+dn: cn=Simpsons,ou=groups,dc=yourcompany,dc=com
+cn: Simpsons
+memberUid: bart
+memberUid: lisa
+objectClass: groupOfUniqueNames
+
+dn: cn=FamilyGuy,ou=groups,dc=yourcompany,dc=com
+cn: FamilyGuy
+memberUid: peter
+memberUid: lois
+objectClass: groupOfUniqueNames
+
+dn: cn=bart,ou=people,dc=yourcompany,dc=com
+cn: Bart Simpson
+sn: Simpson
+givenName: Bart
+uid: bart
+objectClass: inetOrgPerson
+
+dn: cn=lisa,ou=people,dc=yourcompany,dc=com
+cn: Lisa Simpson
+sn: Simpson
+givenName: Lisa
+uid: lisa
+objectClass: inetOrgPerson
+
+dn: cn=peter,ou=people,dc=yourcompany,dc=com
+cn: Peter Griffin
+sn: Griffin
+givenName: Peter
+uid: peter
+objectClass: inetOrgPerson
+userpassword: griffin
+
+dn: cn=lois,ou=people,dc=yourcompany,dc=com
+cn: Lois Griffin
+sn: Griffin
+givenName: Lois
+uid: lois
+objectClass: inetOrgPerson


### PR DESCRIPTION
This can be used for authentication required for manual promotion or for all
REST apis in future

- Added LDAP client support using JNDI.
- Using dropwizard basic HTTP authenticator support for fetching the attributes from client.
- Added LDAP test server using unboundid's in-memory ldap server.
- Added spock and cucumber tests

References #157