### PR TITLE
Add ldap config to all deploydb config files used in cucumber tests

### DIFF
--- a/deploydb.mysql.cucumber.yml
+++ b/deploydb.mysql.cucumber.yml
@@ -23,3 +23,18 @@ logging:
       threshold: ALL
       archive: false
       timeZone: UTC
+
+ldap:
+  uri: ldap://localhost:10389
+  cachePolicy: maximumSize=10000, expireAfterWrite=10m
+  baseDC: "dc=example,dc=com"
+  bindDN: "cn=admin"
+  bindPassword: "secret"
+  userNamePrefix: cn
+  userObjectClass: posixUser
+  groupNamePrefix: cn
+  groupMembershipPrefix: memberUid
+  groupObjectClass: posixGroup
+  distinguishedNamePrefix: entryDN
+  connectTimeout: 500ms
+  readTimeout: 500ms

--- a/deploydb.postgres.cucumber.yml
+++ b/deploydb.postgres.cucumber.yml
@@ -28,3 +28,18 @@ logging:
       threshold: ALL
       archive: false
       timeZone: UTC
+
+ldap:
+  uri: ldap://localhost:10389
+  cachePolicy: maximumSize=10000, expireAfterWrite=10m
+  baseDC: "dc=example,dc=com"
+  bindDN: "cn=admin"
+  bindPassword: "secret"
+  userNamePrefix: cn
+  userObjectClass: posixUser
+  groupNamePrefix: cn
+  groupMembershipPrefix: memberUid
+  groupObjectClass: posixGroup
+  distinguishedNamePrefix: entryDN
+  connectTimeout: 500ms
+  readTimeout: 500ms

--- a/features/api/promotion/creating.feature
+++ b/features/api/promotion/creating.feature
@@ -30,15 +30,23 @@ Feature: Promotion Result APIs
     """
 
 
-  @freezetime @wip
-  Scenario: (issue 166) Adding a result for a Manual LDAP Promotion associated with a Deployment succeeds
+  @freezetime
+  Scenario: Adding a result for a Manual LDAP Promotion associated with a Deployment
+            succeeds only if user belongs to the configured group
 
-    Given a manual LDAP promotion is configured
-    And there is a deployment with manual LDAP promotion
+    Given a promotion configuration name "manualPromo":
+    """
+    type:  deploydb.models.promotion.ManualLDAPPromotionImpl
+    description: "Manual LDAP Promotion"
+    attributes:
+      allowedGroup: fox
+
+    """
+    And there is a deployment with "manualPromo" promotion
     When I POST to "/api/deployments/1/promotions" with credentials "peter:griffin" and:
     """
       {
-        "name"  : "manual-promotion",
+        "name"  : "manualPromo",
         "status" : "SUCCESS"
       }
     """
@@ -47,7 +55,7 @@ Feature: Promotion Result APIs
     """
       {
         "id" : 1,
-        "promotion" : "manual-promotion",
+        "promotion" : "manualPromo",
         "status" : "SUCCESS",
         "infoUrl" : null,
         "createdAt" : "{{created_timestamp}}"

--- a/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
+++ b/src/cucumber/groovy/deploydb/cucumber/ModelHelper.groovy
@@ -53,14 +53,6 @@ class ModelHelper {
                 'jenkins-smoke for Fun as a Service')
     }
 
-    Promotion sampleManualLDAPPromotion() {
-        Promotion promotion = new Promotion("manual-promotion",
-                "deploydb.models.promotion.ManualLDAPPromotionImpl",
-                "Manual Promotion smoke test")
-        promotion.attributes = ["allowedGroup":"fox"]
-        return promotion
-    }
-
     /**
      * Creates a sample environment object
      */

--- a/src/cucumber/groovy/step_definitions/DeploymentSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/DeploymentSteps.groovy
@@ -178,7 +178,7 @@ And(~/the first deployments is in "(.*?)" state$/) { String deploymentState ->
     }
 }
 
-Given(~/^there is a deployment with manual LDAP promotion$/) { ->
+Given(~/^there is a deployment with "(.*?)" promotion$/) { String promotionIdent ->
     withSession {
 
         /**
@@ -191,7 +191,7 @@ Given(~/^there is a deployment with manual LDAP promotion$/) { ->
         /**
          * Create sample promotion & promotionResult(s)
          */
-        PromotionResult p1 = new PromotionResult("manual-promotion", Status.STARTED, null)
+        PromotionResult p1 = new PromotionResult(promotionIdent, Status.STARTED, null)
 
         /**
          * Create deployment

--- a/src/cucumber/groovy/step_definitions/PromotionSteps.groovy
+++ b/src/cucumber/groovy/step_definitions/PromotionSteps.groovy
@@ -29,11 +29,3 @@ Given(~/^promotions are configured$/) { ->
         promotionRegistry.put(b.ident, b)
     }
 }
-
-
-Given(~/^a manual LDAP promotion is configured$/) { ->
-    withPromotionRegistry { ModelRegistry<Promotion> promotionRegistry ->
-        Promotion a = sampleManualLDAPPromotion()
-        promotionRegistry.put(a.ident, a)
-    }
-}


### PR DESCRIPTION
Also, make the manual LDAP authentication scenario self-explanatory.

References #166